### PR TITLE
CON-2003-Enable-MFA-On-Admin-Creation

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
@@ -44,7 +44,6 @@ public class UserService {
         userDto.sendUserRegistrationEmail(properties.isSendUserRegistrationEmail());
         userDto.setAccountVerified(properties.isAccountVerified());
         if (user.isRoleAdmin(user.getUserRoles())) {
-            System.out.println("WZ310");
             userDto.setMfaEnabled(true);
         }
 


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2003**
Enable the user account's MFA, when the org role is an Administrator.