### PR TITLE
CON-2153: Add a first simple application test

### DIFF
--- a/src/test/java/uk/gov/ccs/conclave/data/migration/DataMigrationApiControllerTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/DataMigrationApiControllerTest.java
@@ -1,0 +1,36 @@
+package uk.gov.ccs.conclave.data.migration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.ccs.conclave.data.migration.controller.DataMigrationApiController;
+import uk.gov.ccs.conclave.data.migration.service.MigrationService;
+import uk.gov.ccs.swagger.dataMigration.model.Organisation;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DataMigrationApiController.class)
+@AutoConfigureMockMvc
+public class DataMigrationApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MigrationService service;
+
+    @Test
+    public void shouldBeSuccessful() throws Exception {
+        String organisations = new ObjectMapper().writeValueAsString(List.of(new Organisation()));
+
+        this.mockMvc.perform(post("/data-migration/migrate/format/json").contentType(MediaType.APPLICATION_JSON).content(organisations)).andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/CON-2153

At the moment, the only unit test we have covers a CSV helper. I would like to be able to write unit tests for any new features or fixes. Create a simple application test as an example of how to do such tests.

Since we are mocking the MigrationService, this isn't actually testing very much. But it should be something we can build on for more meaningful tests.

The trick here is that mocking the MigrationService avoids the need for any of the complex configuration that makes it so difficult to run the app locally.