### PR TITLE
CON-2153: Add `isBuyer` when adding organisation roles

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
@@ -96,9 +96,9 @@ public class OrganisationService {
                 OrganisationProfileInfo conclaveOrgProfile = buildOrgProfileRequest(ciiResponse, org);
                 conclaveClient.createConclaveOrg(conclaveOrgProfile);
                 contactService.migrateOrgContact(org, ciiResponse, organisationId);
-                roleService.applyOrganisationRole(organisationId, org.getOrgRoles());
+                roleService.applyOrganisationRole(organisationId, org);
             } else {
-                roleService.applyOrganisationRole(organisationId, org.getOrgRoles());
+                roleService.applyOrganisationRole(organisationId, org);
             }
 
         } catch (uk.gov.ccs.swagger.sso.ApiException e) {

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/RoleService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/RoleService.java
@@ -3,8 +3,8 @@ package uk.gov.ccs.conclave.data.migration.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.ccs.conclave.data.migration.client.ConclaveClient;
-import uk.gov.ccs.conclave.data.migration.exception.DataMigrationException;
 import uk.gov.ccs.swagger.dataMigration.model.OrgRoles;
+import uk.gov.ccs.swagger.dataMigration.model.Organisation;
 import uk.gov.ccs.swagger.dataMigration.model.UserRoles;
 import uk.gov.ccs.swagger.sso.ApiException;
 import uk.gov.ccs.swagger.sso.model.OrganisationRole;
@@ -29,17 +29,18 @@ public class RoleService {
 
     }
 
-    public void applyOrganisationRole(final String organisationId, final List<OrgRoles> orgRolesList) throws ApiException, DataMigrationException {
+    public void applyOrganisationRole(final String organisationId, final Organisation organisation) throws ApiException {
+        var orgRolesList = organisation.getOrgRoles();
         if (isNotEmpty(orgRolesList) && isNotNull(orgRolesList)) {
-
             List<OrganisationRole> configuredRoles = conclaveClient.getAllConfiguredRoles();
             var rolesToAdd = new ArrayList<OrganisationRole>();
             for (OrgRoles orgRole : orgRolesList) {
                 rolesToAdd.add(filterOrganisationRoleByName(configuredRoles, orgRole.getName()));
             }
-            OrganisationRoleUpdate roleUpdate = new OrganisationRoleUpdate();
-            roleUpdate.setRolesToAdd(rolesToAdd);
-            conclaveClient.updateOrganisationRole(organisationId, roleUpdate);
+            conclaveClient.updateOrganisationRole(
+                    organisationId,
+                    new OrganisationRoleUpdate().rolesToAdd(rolesToAdd).isBuyer(organisation.isRightToBuy())
+            );
         }
     }
 

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/RoleServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/RoleServiceTest.java
@@ -1,0 +1,75 @@
+package uk.gov.ccs.conclave.data.migration.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ccs.conclave.data.migration.client.ConclaveClient;
+import uk.gov.ccs.swagger.dataMigration.model.OrgRoles;
+import uk.gov.ccs.swagger.dataMigration.model.Organisation;
+import uk.gov.ccs.swagger.sso.ApiException;
+import uk.gov.ccs.swagger.sso.model.OrganisationRole;
+import uk.gov.ccs.swagger.sso.model.OrganisationRoleUpdate;
+
+import java.util.List;
+
+import static java.util.Collections.EMPTY_LIST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class RoleServiceTest {
+    private final String ORGANISATION_ID = "Organisation ID";
+
+    @Mock
+    private ConclaveClient conclaveClient;
+
+    @InjectMocks
+    private RoleService roleService;
+
+    @Test
+    public void shouldNotAddRolesIfNoRoles() throws Exception {
+        roleService.applyOrganisationRole(ORGANISATION_ID, new Organisation());
+
+        verify(conclaveClient, times(0)).updateOrganisationRole(any(), any());
+    }
+
+    @Test
+    public void shouldNotAddRolesIfZeroRoles() throws Exception {
+        roleService.applyOrganisationRole(ORGANISATION_ID, new Organisation().orgRoles(EMPTY_LIST));
+
+        verify(conclaveClient, times(0)).updateOrganisationRole(any(), any());
+    }
+
+    @Test
+    public void shouldNotAddMalformedRoles() throws Exception {
+        roleService.applyOrganisationRole(ORGANISATION_ID, new Organisation().orgRoles(List.of(new OrgRoles())));
+
+        verify(conclaveClient, times(0)).updateOrganisationRole(any(), any());
+    }
+
+    @Test
+    public void shouldErrorIfRoleDoesNotExist() {
+        assertThrows(ApiException.class, () ->
+                roleService.applyOrganisationRole(ORGANISATION_ID, new Organisation().orgRoles(List.of(new OrgRoles().name("Org Role")))));
+    }
+
+    @Test
+    public void shouldAddOrgRoles() throws Exception {
+        var roleName = "Org Role";
+        given(conclaveClient.getAllConfiguredRoles()).willReturn(List.of(new OrganisationRole().roleName(roleName)));
+
+        roleService.applyOrganisationRole(ORGANISATION_ID, new Organisation().orgRoles(List.of(new OrgRoles().name(roleName))));
+
+        ArgumentCaptor<OrganisationRoleUpdate> argumentCaptor = ArgumentCaptor.forClass(OrganisationRoleUpdate.class);
+        verify(conclaveClient).updateOrganisationRole(eq(ORGANISATION_ID), argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getRolesToAdd().get(0).getRoleName()).isEqualTo(roleName);
+    }
+}

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/RoleServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/RoleServiceTest.java
@@ -72,4 +72,16 @@ public class RoleServiceTest {
         verify(conclaveClient).updateOrganisationRole(eq(ORGANISATION_ID), argumentCaptor.capture());
         assertThat(argumentCaptor.getValue().getRolesToAdd().get(0).getRoleName()).isEqualTo(roleName);
     }
+
+    @Test
+    public void shouldPassBuyerStatus() throws Exception {
+        var roleName = "Org Role";
+        given(conclaveClient.getAllConfiguredRoles()).willReturn(List.of(new OrganisationRole().roleName(roleName)));
+
+        roleService.applyOrganisationRole(ORGANISATION_ID, new Organisation().orgRoles(List.of(new OrgRoles().name(roleName))).rightToBuy(true));
+
+        ArgumentCaptor<OrganisationRoleUpdate> argumentCaptor = ArgumentCaptor.forClass(OrganisationRoleUpdate.class);
+        verify(conclaveClient).updateOrganisationRole(eq(ORGANISATION_ID), argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().isIsBuyer()).isEqualTo(true);
+    }
 }


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/CON-2153

This is a workaround for a bug in either SSO or its swagger spec. Previously, we were not including `isBuyer` when adding organisation roles. This is legal according to the swagger spec. I would expect that SSO would not change `isBuyer` if DM omitted it. The problem is that SSO was setting `isBuyer` to false on the basis of our requests.

This should be fixed in SSO or its swagger spec. However, given the time pressures, let's add a workaround to always provide `isBuyer`. We may be able to revert this once SSO is fixed, but this should unblock testing in the interim.

Add unit tests for both the existing and new functionality in this area.