### PR TITLE
CON-2601: Update CII API spec to match what we're using

### DIFF
--- a/src/main/java/uk/gov/ccs/swagger/cii/ApiException.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/ApiException.java
@@ -15,7 +15,7 @@ package uk.gov.ccs.swagger.cii;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")public class ApiException extends Exception {
+public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/src/main/java/uk/gov/ccs/swagger/cii/Configuration.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/Configuration.java
@@ -12,7 +12,7 @@
 
 package uk.gov.ccs.swagger.cii;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")public class Configuration {
+public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 
     /**

--- a/src/main/java/uk/gov/ccs/swagger/cii/Pair.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/Pair.java
@@ -12,7 +12,7 @@
 
 package uk.gov.ccs.swagger.cii;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")public class Pair {
+public class Pair {
     private String name = "";
     private String value = "";
 

--- a/src/main/java/uk/gov/ccs/swagger/cii/StringUtil.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/StringUtil.java
@@ -12,7 +12,7 @@
 
 package uk.gov.ccs.swagger.cii;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")public class StringUtil {
+public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).
    *

--- a/src/main/java/uk/gov/ccs/swagger/cii/api/IdentitiesApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/api/IdentitiesApi.java
@@ -54,6 +54,131 @@ public class IdentitiesApi {
     }
 
     /**
+     * Build call for appDeleteOrg
+     * @param organisationId organisationId is the organisation&#x27;s unique id, that is used to identify them (required)
+     * @param progressListener Progress listener
+     * @param progressRequestListener Progress request listener
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     */
+    public com.squareup.okhttp.Call appDeleteOrgCall(String organisationId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        Object localVarPostBody = null;
+        
+        // create path and map variables
+        String localVarPath = "/identities/organisations/{organisationId}"
+            .replaceAll("\\{" + "organisationId" + "\\}", apiClient.escapeString(organisationId.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
+
+        final String[] localVarContentTypes = {
+            
+        };
+        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        if(progressListener != null) {
+            apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
+                @Override
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
+                    com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
+                    return originalResponse.newBuilder()
+                    .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+                    .build();
+                }
+            });
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+    }
+    
+    @SuppressWarnings("rawtypes")
+    private com.squareup.okhttp.Call appDeleteOrgValidateBeforeCall(String organisationId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        // verify the required parameter 'organisationId' is set
+        if (organisationId == null) {
+            throw new ApiException("Missing the required parameter 'organisationId' when calling appDeleteOrg(Async)");
+        }
+        
+        com.squareup.okhttp.Call call = appDeleteOrgCall(organisationId, progressListener, progressRequestListener);
+        return call;
+
+        
+        
+        
+        
+    }
+
+    /**
+     * A generic endpoint for deleting organisations from data file supplied by individual CCS platforms and services.
+     * 
+     * @param organisationId organisationId is the organisation&#x27;s unique id, that is used to identify them (required)
+     * @return OrgMigration
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public OrgMigration appDeleteOrg(String organisationId) throws ApiException {
+        ApiResponse<OrgMigration> resp = appDeleteOrgWithHttpInfo(organisationId);
+        return resp.getData();
+    }
+
+    /**
+     * A generic endpoint for deleting organisations from data file supplied by individual CCS platforms and services.
+     * 
+     * @param organisationId organisationId is the organisation&#x27;s unique id, that is used to identify them (required)
+     * @return ApiResponse&lt;OrgMigration&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public ApiResponse<OrgMigration> appDeleteOrgWithHttpInfo(String organisationId) throws ApiException {
+        com.squareup.okhttp.Call call = appDeleteOrgValidateBeforeCall(organisationId, null, null);
+        Type localVarReturnType = new TypeToken<OrgMigration>(){}.getType();
+        return apiClient.execute(call, localVarReturnType);
+    }
+
+    /**
+     * A generic endpoint for deleting organisations from data file supplied by individual CCS platforms and services. (asynchronously)
+     * 
+     * @param organisationId organisationId is the organisation&#x27;s unique id, that is used to identify them (required)
+     * @param callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     */
+    public com.squareup.okhttp.Call appDeleteOrgAsync(String organisationId, final ApiCallback<OrgMigration> callback) throws ApiException {
+
+        ProgressResponseBody.ProgressListener progressListener = null;
+        ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
+
+        if (callback != null) {
+            progressListener = new ProgressResponseBody.ProgressListener() {
+                @Override
+                public void update(long bytesRead, long contentLength, boolean done) {
+                    callback.onDownloadProgress(bytesRead, contentLength, done);
+                }
+            };
+
+            progressRequestListener = new ProgressRequestBody.ProgressRequestListener() {
+                @Override
+                public void onRequestProgress(long bytesWritten, long contentLength, boolean done) {
+                    callback.onUploadProgress(bytesWritten, contentLength, done);
+                }
+            };
+        }
+
+        com.squareup.okhttp.Call call = appDeleteOrgValidateBeforeCall(organisationId, progressListener, progressRequestListener);
+        Type localVarReturnType = new TypeToken<OrgMigration>(){}.getType();
+        apiClient.executeAsync(call, localVarReturnType, callback);
+        return call;
+    }
+    /**
      * Build call for appMigrateOrg
      * @param scheme scheme code is the code to the identifier for e.g. GB-COH is Companies House and US-DUNS is Duns and Bradstreet (required)
      * @param id scheme ID for scheme 05606089 (required)
@@ -92,7 +217,7 @@ public class IdentitiesApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -103,56 +228,6 @@ public class IdentitiesApi {
 
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
-    }
-
-    /**
-     * Build call for appDeleteOrg
-     * @param organisationId organisationId is the organisation's unique id, that is used to identify them
-     * @param progressListener Progress listener
-     * @param progressRequestListener Progress request listener
-     * @return Call to execute
-     * @throws ApiException If fail to serialize the request body object
-     */
-    public com.squareup.okhttp.Call appDeleteOrgCall(String organisationId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        Object localVarPostBody = null;
-        
-        // create path and map variables
-        String localVarPath = "/identities/organisations/{organisationId}"
-            .replaceAll("\\{" + "organisationId" + "\\}", apiClient.escapeString(organisationId.toString()));
-
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
-        final String[] localVarAccepts = {
-            "application/json"
-        };
-        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-        if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
-
-        final String[] localVarContentTypes = {
-            
-        };
-        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-        localVarHeaderParams.put("Content-Type", localVarContentType);
-
-        if(progressListener != null) {
-            apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
-                @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
-                    com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
-                    return originalResponse.newBuilder()
-                    .body(new ProgressResponseBody(originalResponse.body(), progressListener))
-                    .build();
-                }
-            });
-        }
-
-        String[] localVarAuthNames = new String[] {  };
-        return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
     
     @SuppressWarnings("rawtypes")
@@ -175,22 +250,6 @@ public class IdentitiesApi {
         
     }
 
-    @SuppressWarnings("rawtypes")
-    private com.squareup.okhttp.Call appDeleteOrgValidateBeforeCall(String organisationId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        // verify the required parameter 'organisationId' is set
-        if (organisationId == null) {
-            throw new ApiException("Missing the required parameter 'organisationId' when calling appDeleteOrg(Async)");
-        }
-        
-        com.squareup.okhttp.Call call = appDeleteOrgCall(organisationId, progressListener, progressRequestListener);
-        return call;
-
-        
-        
-        
-        
-    }
-
     /**
      * A generic endpoint for regisering organisations from data file supplied by individual CCS platforms and services.
      * 
@@ -205,18 +264,6 @@ public class IdentitiesApi {
     }
 
     /**
-     * A generic endpoint for deleting organisations from data file supplied by individual CCS platforms and services.
-     * 
-     * @param organisationId organisationId is the organisation's unique id, that is used to identify them
-     * @return OrgDelete
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     */
-    public OrgMigration appDeleteOrg(String organisationId) throws ApiException {
-        ApiResponse<OrgMigration> resp = appDeleteOrgWithHttpInfo(organisationId);
-        return resp.getData();
-    }
-
-    /**
      * A generic endpoint for regisering organisations from data file supplied by individual CCS platforms and services.
      * 
      * @param scheme scheme code is the code to the identifier for e.g. GB-COH is Companies House and US-DUNS is Duns and Bradstreet (required)
@@ -226,19 +273,6 @@ public class IdentitiesApi {
      */
     public ApiResponse<OrgMigration> appMigrateOrgWithHttpInfo(String scheme, String id) throws ApiException {
         com.squareup.okhttp.Call call = appMigrateOrgValidateBeforeCall(scheme, id, null, null);
-        Type localVarReturnType = new TypeToken<OrgMigration>(){}.getType();
-        return apiClient.execute(call, localVarReturnType);
-    }
-
-    /**
-     * A generic endpoint for deleting organisations from data file supplied by individual CCS platforms and services.
-     * 
-     * @param organisationId organisationId is the organisation's unique id, that is used to identify them
-     * @return ApiResponse&lt;OrgDelete&gt;
-     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-     */
-    public ApiResponse<OrgMigration> appDeleteOrgWithHttpInfo(String organisationId) throws ApiException {
-        com.squareup.okhttp.Call call = appDeleteOrgValidateBeforeCall(organisationId, null, null);
         Type localVarReturnType = new TypeToken<OrgMigration>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
@@ -274,41 +308,6 @@ public class IdentitiesApi {
         }
 
         com.squareup.okhttp.Call call = appMigrateOrgValidateBeforeCall(scheme, id, progressListener, progressRequestListener);
-        Type localVarReturnType = new TypeToken<OrgMigration>(){}.getType();
-        apiClient.executeAsync(call, localVarReturnType, callback);
-        return call;
-    }
-
-    /**
-     * A generic endpoint for deleting organisations from data file supplied by individual CCS platforms and services. (asynchronously)
-     * 
-     * @param organisationId organisationId is the organisation's unique id, that is used to identify them
-     * @param callback The callback to be executed when the API call finishes
-     * @return The request call
-     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
-     */
-    public com.squareup.okhttp.Call appDeleteOrgAsync(String organisationId, final ApiCallback<OrgMigration> callback) throws ApiException {
-
-        ProgressResponseBody.ProgressListener progressListener = null;
-        ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
-
-        if (callback != null) {
-            progressListener = new ProgressResponseBody.ProgressListener() {
-                @Override
-                public void update(long bytesRead, long contentLength, boolean done) {
-                    callback.onDownloadProgress(bytesRead, contentLength, done);
-                }
-            };
-
-            progressRequestListener = new ProgressRequestBody.ProgressRequestListener() {
-                @Override
-                public void onRequestProgress(long bytesWritten, long contentLength, boolean done) {
-                    callback.onUploadProgress(bytesWritten, contentLength, done);
-                }
-            };
-        }
-
-        com.squareup.okhttp.Call call = appDeleteOrgValidateBeforeCall(organisationId, progressListener, progressRequestListener);
         Type localVarReturnType = new TypeToken<OrgMigration>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;

--- a/src/main/java/uk/gov/ccs/swagger/cii/auth/ApiKeyAuth.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/auth/ApiKeyAuth.java
@@ -17,7 +17,7 @@ import uk.gov.ccs.swagger.cii.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")public class ApiKeyAuth implements Authentication {
+public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;
 

--- a/src/main/java/uk/gov/ccs/swagger/cii/auth/OAuth.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/auth/OAuth.java
@@ -17,7 +17,7 @@ import uk.gov.ccs.swagger.cii.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")public class OAuth implements Authentication {
+public class OAuth implements Authentication {
   private String accessToken;
 
   public String getAccessToken() {

--- a/src/main/java/uk/gov/ccs/swagger/cii/model/Address.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/model/Address.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * Address
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")
+
 public class Address {
   @SerializedName("streetAddress")
   private String streetAddress = null;
@@ -134,7 +134,7 @@ public class Address {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -173,7 +173,7 @@ public class Address {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/cii/model/ContactPoint.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/model/ContactPoint.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * ContactPoint
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")
+
 public class ContactPoint {
   @SerializedName("name")
   private String name = null;
@@ -155,7 +155,7 @@ public class ContactPoint {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -196,7 +196,7 @@ public class ContactPoint {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/cii/model/Identifier.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/model/Identifier.java
@@ -26,7 +26,7 @@ import uk.gov.ccs.swagger.cii.model.OrganizationScheme;
  * A unique identifier for a party (organization).
  */
 @Schema(description = "A unique identifier for a party (organization).")
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")
+
 public class Identifier {
   @SerializedName("scheme")
   private OrganizationScheme scheme = null;
@@ -114,7 +114,7 @@ public class Identifier {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -151,7 +151,7 @@ public class Identifier {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/cii/model/OrgMigration.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/model/OrgMigration.java
@@ -30,7 +30,7 @@ import uk.gov.ccs.swagger.cii.model.Identifier;
  * OrgMigration
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-10-25T10:32:06.874824+01:00[Europe/London]")
+
 public class OrgMigration {
   @SerializedName("organisationId")
   private String organisationId = null;
@@ -147,7 +147,7 @@ public class OrgMigration {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -186,7 +186,7 @@ public class OrgMigration {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/cii/model/OrganizationScheme.java
+++ b/src/main/java/uk/gov/ccs/swagger/cii/model/OrganizationScheme.java
@@ -53,9 +53,9 @@ public enum OrganizationScheme {
     return String.valueOf(value);
   }
 
-  public static OrganizationScheme fromValue(String text) {
+  public static OrganizationScheme fromValue(String input) {
     for (OrganizationScheme b : OrganizationScheme.values()) {
-      if (String.valueOf(b.value).equals(text)) {
+      if (b.value.equals(input)) {
         return b;
       }
     }
@@ -65,13 +65,13 @@ public enum OrganizationScheme {
   public static class Adapter extends TypeAdapter<OrganizationScheme> {
     @Override
     public void write(final JsonWriter jsonWriter, final OrganizationScheme enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      jsonWriter.value(String.valueOf(enumeration.getValue()));
     }
 
     @Override
     public OrganizationScheme read(final JsonReader jsonReader) throws IOException {
       Object value = jsonReader.nextString();
-      return OrganizationScheme.fromValue(String.valueOf(value));
+      return OrganizationScheme.fromValue((String)(value));
     }
   }
 }

--- a/src/main/resources/cii_api.yaml
+++ b/src/main/resources/cii_api.yaml
@@ -97,6 +97,10 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrgMigration'
         "400":
           description: Bad Request
         "401":
@@ -173,6 +177,7 @@ components:
       - faxNumber
       - name
       - telephone
+      - mobile
       - uri
       type: object
       properties:
@@ -188,6 +193,10 @@ components:
           type: string
           description: The telephone number of the contact point/person. This should include the international dialling code.
           example: 020 7777 7777
+        mobile:
+          type: string
+          description: The mobile number of the contact point/person. This should include the international dialling code.
+          example: +44 7777 7777
         faxNumber:
           type: string
           description: The fax number of the contact point/person. This should include the international dialling code.


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/CON-2601

The CII API has seen some changes since it was last updated in this repo - https://crowncommercialservice.atlassian.net/browse/CON-1150. Update the spec and then regenerate the client. As far as I can see, this has not made any meaningful changes to the client.

There exists an 'official' version of the API spec on swaggerhub: https://app.swaggerhub.com/apis/miahnanu/CII/1.0.4. However, that version is very different to what we're using - it's missing the delete endpoint and the mobile and URI fields. So I don't think it's worth trying to switch across to that version yet.