### PR TITLE
CON-2601: Regenerate SSO API client from API spec

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
@@ -37,7 +37,7 @@ public class UserService {
     private UserProfileEditRequestInfo populateUserProfileInfo(User user, String organisationId, Integer identityProvideId, List<Integer> roleIds) {
 
         UserProfileEditRequestInfo userDto = new UserProfileEditRequestInfo();
-        userDto.setTitle(fromValue(user.getTitle()));
+        userDto.setTitle(fromValue(Integer.valueOf(user.getTitle())));
         userDto.setFirstName(user.getFirstName());
         userDto.setLastName(user.getLastName());
         userDto.setUserName(user.getEmail());

--- a/src/main/java/uk/gov/ccs/swagger/sso/ApiException.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/ApiException.java
@@ -15,7 +15,7 @@ package uk.gov.ccs.swagger.sso;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")public class ApiException extends Exception {
+public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/src/main/java/uk/gov/ccs/swagger/sso/Configuration.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/Configuration.java
@@ -12,7 +12,7 @@
 
 package uk.gov.ccs.swagger.sso;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")public class Configuration {
+public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 
     /**

--- a/src/main/java/uk/gov/ccs/swagger/sso/Pair.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/Pair.java
@@ -12,7 +12,7 @@
 
 package uk.gov.ccs.swagger.sso;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")public class Pair {
+public class Pair {
     private String name = "";
     private String value = "";
 

--- a/src/main/java/uk/gov/ccs/swagger/sso/StringUtil.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/StringUtil.java
@@ -12,7 +12,7 @@
 
 package uk.gov.ccs.swagger.sso;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")public class StringUtil {
+public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).
    *

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/ConfigurationApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/ConfigurationApi.java
@@ -91,7 +91,7 @@ public class ConfigurationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -207,7 +207,7 @@ public class ConfigurationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -328,7 +328,7 @@ public class ConfigurationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -454,7 +454,7 @@ public class ConfigurationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/ContactApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/ContactApi.java
@@ -90,7 +90,7 @@ public class ContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -206,7 +206,7 @@ public class ContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -324,7 +324,7 @@ public class ContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -445,7 +445,7 @@ public class ContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -571,7 +571,7 @@ public class ContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -694,7 +694,7 @@ public class ContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationApi.java
@@ -95,7 +95,7 @@ public class OrganisationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -220,7 +220,7 @@ public class OrganisationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -346,7 +346,7 @@ public class OrganisationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -471,7 +471,7 @@ public class OrganisationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -595,7 +595,7 @@ public class OrganisationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -721,7 +721,7 @@ public class OrganisationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -844,7 +844,7 @@ public class OrganisationApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationContactApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationContactApi.java
@@ -97,7 +97,7 @@ public class OrganisationContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -222,7 +222,7 @@ public class OrganisationContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -352,7 +352,7 @@ public class OrganisationContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -482,7 +482,7 @@ public class OrganisationContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -617,7 +617,7 @@ public class OrganisationContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -754,7 +754,7 @@ public class OrganisationContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -886,7 +886,7 @@ public class OrganisationContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationGroupApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationGroupApi.java
@@ -96,7 +96,7 @@ public class OrganisationGroupApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -226,7 +226,7 @@ public class OrganisationGroupApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -356,7 +356,7 @@ public class OrganisationGroupApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -491,7 +491,7 @@ public class OrganisationGroupApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -623,7 +623,7 @@ public class OrganisationGroupApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationSiteApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationSiteApi.java
@@ -95,7 +95,7 @@ public class OrganisationSiteApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -224,7 +224,7 @@ public class OrganisationSiteApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -354,7 +354,7 @@ public class OrganisationSiteApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -484,7 +484,7 @@ public class OrganisationSiteApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -619,7 +619,7 @@ public class OrganisationSiteApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationSiteContactApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationSiteContactApi.java
@@ -99,7 +99,7 @@ public class OrganisationSiteContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -233,7 +233,7 @@ public class OrganisationSiteContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -372,7 +372,7 @@ public class OrganisationSiteContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -511,7 +511,7 @@ public class OrganisationSiteContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -655,7 +655,7 @@ public class OrganisationSiteContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -801,7 +801,7 @@ public class OrganisationSiteContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -942,7 +942,7 @@ public class OrganisationSiteContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationUserApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/OrganisationUserApi.java
@@ -102,7 +102,7 @@ public class OrganisationUserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/UserApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/UserApi.java
@@ -93,7 +93,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -215,7 +215,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -333,7 +333,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -451,7 +451,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -569,7 +569,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -694,7 +694,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -813,7 +813,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -936,7 +936,7 @@ public class UserApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/api/UserContactApi.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/api/UserContactApi.java
@@ -95,7 +95,7 @@ public class UserContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -222,7 +222,7 @@ public class UserContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -354,7 +354,7 @@ public class UserContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -485,7 +485,7 @@ public class UserContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
@@ -611,7 +611,7 @@ public class UserContactApi {
         if(progressListener != null) {
             apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
                 @Override
-                public com.squareup.okhttp.Response intercept(Chain chain) throws IOException {
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
                     com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
                     return originalResponse.newBuilder()
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))

--- a/src/main/java/uk/gov/ccs/swagger/sso/auth/ApiKeyAuth.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/auth/ApiKeyAuth.java
@@ -17,7 +17,7 @@ import uk.gov.ccs.swagger.sso.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")public class ApiKeyAuth implements Authentication {
+public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;
 

--- a/src/main/java/uk/gov/ccs/swagger/sso/auth/OAuth.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/auth/OAuth.java
@@ -17,7 +17,7 @@ import uk.gov.ccs.swagger.sso.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")public class OAuth implements Authentication {
+public class OAuth implements Authentication {
   private String accessToken;
 
   public String getAccessToken() {

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/AssignedContactType.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/AssignedContactType.java
@@ -45,9 +45,9 @@ public enum AssignedContactType {
     return String.valueOf(value);
   }
 
-  public static AssignedContactType fromValue(String text) {
+  public static AssignedContactType fromValue(Integer input) {
     for (AssignedContactType b : AssignedContactType.values()) {
-      if (String.valueOf(b.value).equals(text)) {
+      if (b.value.equals(input)) {
         return b;
       }
     }
@@ -57,13 +57,13 @@ public enum AssignedContactType {
   public static class Adapter extends TypeAdapter<AssignedContactType> {
     @Override
     public void write(final JsonWriter jsonWriter, final AssignedContactType enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      jsonWriter.value(String.valueOf(enumeration.getValue()));
     }
 
     @Override
     public AssignedContactType read(final JsonReader jsonReader) throws IOException {
       Object value = jsonReader.nextInt();
-      return AssignedContactType.fromValue(String.valueOf(value));
+      return AssignedContactType.fromValue((Integer)(value));
     }
   }
 }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/CcsServiceInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/CcsServiceInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * CcsServiceInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class CcsServiceInfo {
   @SerializedName("id")
   private Integer id = null;
@@ -134,7 +134,7 @@ public class CcsServiceInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -173,7 +173,7 @@ public class CcsServiceInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactAssignedStatus.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactAssignedStatus.java
@@ -45,9 +45,9 @@ public enum ContactAssignedStatus {
     return String.valueOf(value);
   }
 
-  public static ContactAssignedStatus fromValue(String text) {
+  public static ContactAssignedStatus fromValue(Integer input) {
     for (ContactAssignedStatus b : ContactAssignedStatus.values()) {
-      if (String.valueOf(b.value).equals(text)) {
+      if (b.value.equals(input)) {
         return b;
       }
     }
@@ -57,13 +57,13 @@ public enum ContactAssignedStatus {
   public static class Adapter extends TypeAdapter<ContactAssignedStatus> {
     @Override
     public void write(final JsonWriter jsonWriter, final ContactAssignedStatus enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      jsonWriter.value(String.valueOf(enumeration.getValue()));
     }
 
     @Override
     public ContactAssignedStatus read(final JsonReader jsonReader) throws IOException {
       Object value = jsonReader.nextInt();
-      return ContactAssignedStatus.fromValue(String.valueOf(value));
+      return ContactAssignedStatus.fromValue((Integer)(value));
     }
   }
 }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactAssignmentInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactAssignmentInfo.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.AssignedContactType;
  * ContactAssignmentInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class ContactAssignmentInfo {
   @SerializedName("assigningContactType")
   private AssignedContactType assigningContactType = null;
@@ -124,7 +124,7 @@ public class ContactAssignmentInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -161,7 +161,7 @@ public class ContactAssignmentInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactReasonInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactReasonInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * ContactReasonInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class ContactReasonInfo {
   @SerializedName("key")
   private String key = null;
@@ -71,7 +71,7 @@ public class ContactReasonInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class ContactReasonInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactRequestDetail.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactRequestDetail.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * ContactRequestDetail
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class ContactRequestDetail {
   @SerializedName("contactType")
   private String contactType = null;
@@ -71,7 +71,7 @@ public class ContactRequestDetail {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class ContactRequestDetail {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactRequestInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactRequestInfo.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.ContactRequestDetail;
  * ContactRequestInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class ContactRequestInfo {
   @SerializedName("contactPointReason")
   private String contactPointReason = null;
@@ -103,7 +103,7 @@ public class ContactRequestInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -138,7 +138,7 @@ public class ContactRequestInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactResponseDetail.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactResponseDetail.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * ContactResponseDetail
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class ContactResponseDetail {
   @SerializedName("contactType")
   private String contactType = null;
@@ -92,7 +92,7 @@ public class ContactResponseDetail {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -127,7 +127,7 @@ public class ContactResponseDetail {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactResponseInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactResponseInfo.java
@@ -29,7 +29,7 @@ import uk.gov.ccs.swagger.sso.model.ContactResponseDetail;
  * ContactResponseInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class ContactResponseInfo {
   @SerializedName("contactPointReason")
   private String contactPointReason = null;
@@ -167,7 +167,7 @@ public class ContactResponseInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -208,7 +208,7 @@ public class ContactResponseInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/GroupAccessRole.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/GroupAccessRole.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * GroupAccessRole
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class GroupAccessRole {
   @SerializedName("groupId")
   private Integer groupId = null;
@@ -155,7 +155,7 @@ public class GroupAccessRole {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -196,7 +196,7 @@ public class GroupAccessRole {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/GroupRole.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/GroupRole.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * GroupRole
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class GroupRole {
   @SerializedName("id")
   private Integer id = null;
@@ -71,7 +71,7 @@ public class GroupRole {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class GroupRole {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/GroupUser.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/GroupUser.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * GroupUser
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class GroupUser {
   @SerializedName("userId")
   private String userId = null;
@@ -71,7 +71,7 @@ public class GroupUser {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class GroupUser {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/IdentityProviderDetail.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/IdentityProviderDetail.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * IdentityProviderDetail
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class IdentityProviderDetail {
   @SerializedName("id")
   private Integer id = null;
@@ -92,7 +92,7 @@ public class IdentityProviderDetail {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -127,7 +127,7 @@ public class IdentityProviderDetail {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrgIdentityProvider.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrgIdentityProvider.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrgIdentityProvider
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrgIdentityProvider {
   @SerializedName("id")
   private Integer id = null;
@@ -113,7 +113,7 @@ public class OrgIdentityProvider {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -150,7 +150,7 @@ public class OrgIdentityProvider {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrgIdentityProviderSummary.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrgIdentityProviderSummary.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.OrgIdentityProvider;
  * OrgIdentityProviderSummary
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrgIdentityProviderSummary {
   @SerializedName("ciiOrganisationId")
   private String ciiOrganisationId = null;
@@ -82,7 +82,7 @@ public class OrgIdentityProviderSummary {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -115,7 +115,7 @@ public class OrgIdentityProviderSummary {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationAddress.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationAddress.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrganisationAddress
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationAddress {
   @SerializedName("streetAddress")
   private String streetAddress = null;
@@ -134,7 +134,7 @@ public class OrganisationAddress {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -173,7 +173,7 @@ public class OrganisationAddress {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationAddressResponse.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationAddressResponse.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrganisationAddressResponse
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationAddressResponse {
   @SerializedName("streetAddress")
   private String streetAddress = null;
@@ -155,7 +155,7 @@ public class OrganisationAddressResponse {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -196,7 +196,7 @@ public class OrganisationAddressResponse {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationContactInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationContactInfo.java
@@ -30,7 +30,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationDetailInfo;
  * OrganisationContactInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationContactInfo {
   @SerializedName("contactPointReason")
   private String contactPointReason = null;
@@ -189,7 +189,7 @@ public class OrganisationContactInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -232,7 +232,7 @@ public class OrganisationContactInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationContactInfoList.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationContactInfoList.java
@@ -29,7 +29,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationDetailInfo;
  * OrganisationContactInfoList
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationContactInfoList {
   @SerializedName("detail")
   private OrganisationDetailInfo detail = null;
@@ -83,7 +83,7 @@ public class OrganisationContactInfoList {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -116,7 +116,7 @@ public class OrganisationContactInfoList {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationDetail.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationDetail.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrganisationDetail
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationDetail {
   @SerializedName("organisationId")
   private String organisationId = null;
@@ -197,7 +197,7 @@ public class OrganisationDetail {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -242,7 +242,7 @@ public class OrganisationDetail {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationDetailInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationDetailInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrganisationDetailInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationDetailInfo {
   @SerializedName("organisationId")
   private String organisationId = null;
@@ -50,7 +50,7 @@ public class OrganisationDetailInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class OrganisationDetailInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrganisationGroupInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationGroupInfo {
   @SerializedName("groupName")
   private String groupName = null;
@@ -92,7 +92,7 @@ public class OrganisationGroupInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -127,7 +127,7 @@ public class OrganisationGroupInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupList.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupList.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationGroupInfo;
  * OrganisationGroupList
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationGroupList {
   @SerializedName("organisationId")
   private String organisationId = null;
@@ -82,7 +82,7 @@ public class OrganisationGroupList {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -115,7 +115,7 @@ public class OrganisationGroupList {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupNameInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupNameInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrganisationGroupNameInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationGroupNameInfo {
   @SerializedName("groupName")
   private String groupName = null;
@@ -50,7 +50,7 @@ public class OrganisationGroupNameInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class OrganisationGroupNameInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupRequestInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupRequestInfo.java
@@ -27,7 +27,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationGroupUserPatchInfo;
  * OrganisationGroupRequestInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationGroupRequestInfo {
   @SerializedName("groupName")
   private String groupName = null;
@@ -94,7 +94,7 @@ public class OrganisationGroupRequestInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -129,7 +129,7 @@ public class OrganisationGroupRequestInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupResponseInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupResponseInfo.java
@@ -29,7 +29,7 @@ import uk.gov.ccs.swagger.sso.model.GroupUser;
  * OrganisationGroupResponseInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationGroupResponseInfo {
   @SerializedName("groupName")
   private String groupName = null;
@@ -196,7 +196,7 @@ public class OrganisationGroupResponseInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -239,7 +239,7 @@ public class OrganisationGroupResponseInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupRolePatchInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupRolePatchInfo.java
@@ -27,7 +27,7 @@ import java.util.List;
  * OrganisationGroupRolePatchInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationGroupRolePatchInfo {
   @SerializedName("addedRoleIds")
   private List<Integer> addedRoleIds = null;
@@ -89,7 +89,7 @@ public class OrganisationGroupRolePatchInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -122,7 +122,7 @@ public class OrganisationGroupRolePatchInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupUserPatchInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationGroupUserPatchInfo.java
@@ -27,7 +27,7 @@ import java.util.List;
  * OrganisationGroupUserPatchInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationGroupUserPatchInfo {
   @SerializedName("addedUserIds")
   private List<String> addedUserIds = null;
@@ -89,7 +89,7 @@ public class OrganisationGroupUserPatchInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -122,7 +122,7 @@ public class OrganisationGroupUserPatchInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationIdentifier.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationIdentifier.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * OrganisationIdentifier
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationIdentifier {
   @SerializedName("id")
   private String id = null;
@@ -113,7 +113,7 @@ public class OrganisationIdentifier {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -150,7 +150,7 @@ public class OrganisationIdentifier {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationProfileInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationProfileInfo.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationIdentifier;
  * OrganisationProfileInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationProfileInfo {
   @SerializedName("identifier")
   private OrganisationIdentifier identifier = null;
@@ -95,7 +95,7 @@ public class OrganisationProfileInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -130,7 +130,7 @@ public class OrganisationProfileInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationProfileResponseInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationProfileResponseInfo.java
@@ -30,7 +30,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationIdentifier;
  * OrganisationProfileResponseInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationProfileResponseInfo {
   @SerializedName("identifier")
   private OrganisationIdentifier identifier = null;
@@ -126,7 +126,7 @@ public class OrganisationProfileResponseInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -163,7 +163,7 @@ public class OrganisationProfileResponseInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationRole.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationRole.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.RoleEligibleTradeType;
  * OrganisationRole
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationRole {
   @SerializedName("roleId")
   private Integer roleId = null;
@@ -179,7 +179,7 @@ public class OrganisationRole {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -222,7 +222,7 @@ public class OrganisationRole {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationRoleUpdate.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationRoleUpdate.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationRole;
  * OrganisationRoleUpdate
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationRoleUpdate {
   @SerializedName("isBuyer")
   private Boolean isBuyer = null;
@@ -111,7 +111,7 @@ public class OrganisationRoleUpdate {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -146,7 +146,7 @@ public class OrganisationRoleUpdate {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSite.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSite.java
@@ -27,7 +27,7 @@ import uk.gov.ccs.swagger.sso.model.SiteDetail;
  * OrganisationSite
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationSite {
   @SerializedName("siteName")
   private String siteName = null;
@@ -94,7 +94,7 @@ public class OrganisationSite {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -129,7 +129,7 @@ public class OrganisationSite {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteContactInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteContactInfo.java
@@ -30,7 +30,7 @@ import uk.gov.ccs.swagger.sso.model.SiteDetailInfo;
  * OrganisationSiteContactInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationSiteContactInfo {
   @SerializedName("contactPointReason")
   private String contactPointReason = null;
@@ -189,7 +189,7 @@ public class OrganisationSiteContactInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -232,7 +232,7 @@ public class OrganisationSiteContactInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteContactInfoList.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteContactInfoList.java
@@ -29,7 +29,7 @@ import uk.gov.ccs.swagger.sso.model.SiteDetailInfo;
  * OrganisationSiteContactInfoList
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationSiteContactInfoList {
   @SerializedName("detail")
   private SiteDetailInfo detail = null;
@@ -83,7 +83,7 @@ public class OrganisationSiteContactInfoList {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -116,7 +116,7 @@ public class OrganisationSiteContactInfoList {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteInfo.java
@@ -26,7 +26,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationAddress;
  * OrganisationSiteInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationSiteInfo {
   @SerializedName("siteName")
   private String siteName = null;
@@ -72,7 +72,7 @@ public class OrganisationSiteInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -105,7 +105,7 @@ public class OrganisationSiteInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteInfoList.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteInfoList.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.OrganisationSite;
  * OrganisationSiteInfoList
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationSiteInfoList {
   @SerializedName("organisationId")
   private String organisationId = null;
@@ -82,7 +82,7 @@ public class OrganisationSiteInfoList {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -115,7 +115,7 @@ public class OrganisationSiteInfoList {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteResponse.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/OrganisationSiteResponse.java
@@ -27,7 +27,7 @@ import uk.gov.ccs.swagger.sso.model.SiteDetail;
  * OrganisationSiteResponse
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class OrganisationSiteResponse {
   @SerializedName("siteName")
   private String siteName = null;
@@ -115,7 +115,7 @@ public class OrganisationSiteResponse {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -152,7 +152,7 @@ public class OrganisationSiteResponse {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/RoleEligibleOrgType.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/RoleEligibleOrgType.java
@@ -45,9 +45,9 @@ public enum RoleEligibleOrgType {
     return String.valueOf(value);
   }
 
-  public static RoleEligibleOrgType fromValue(String text) {
+  public static RoleEligibleOrgType fromValue(Integer input) {
     for (RoleEligibleOrgType b : RoleEligibleOrgType.values()) {
-      if (String.valueOf(b.value).equals(text)) {
+      if (b.value.equals(input)) {
         return b;
       }
     }
@@ -57,13 +57,13 @@ public enum RoleEligibleOrgType {
   public static class Adapter extends TypeAdapter<RoleEligibleOrgType> {
     @Override
     public void write(final JsonWriter jsonWriter, final RoleEligibleOrgType enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      jsonWriter.value(String.valueOf(enumeration.getValue()));
     }
 
     @Override
     public RoleEligibleOrgType read(final JsonReader jsonReader) throws IOException {
       Object value = jsonReader.nextInt();
-      return RoleEligibleOrgType.fromValue(String.valueOf(value));
+      return RoleEligibleOrgType.fromValue((Integer)(value));
     }
   }
 }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/RoleEligibleSubscriptionType.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/RoleEligibleSubscriptionType.java
@@ -44,9 +44,9 @@ public enum RoleEligibleSubscriptionType {
     return String.valueOf(value);
   }
 
-  public static RoleEligibleSubscriptionType fromValue(String text) {
+  public static RoleEligibleSubscriptionType fromValue(Integer input) {
     for (RoleEligibleSubscriptionType b : RoleEligibleSubscriptionType.values()) {
-      if (String.valueOf(b.value).equals(text)) {
+      if (b.value.equals(input)) {
         return b;
       }
     }
@@ -56,13 +56,13 @@ public enum RoleEligibleSubscriptionType {
   public static class Adapter extends TypeAdapter<RoleEligibleSubscriptionType> {
     @Override
     public void write(final JsonWriter jsonWriter, final RoleEligibleSubscriptionType enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      jsonWriter.value(String.valueOf(enumeration.getValue()));
     }
 
     @Override
     public RoleEligibleSubscriptionType read(final JsonReader jsonReader) throws IOException {
       Object value = jsonReader.nextInt();
-      return RoleEligibleSubscriptionType.fromValue(String.valueOf(value));
+      return RoleEligibleSubscriptionType.fromValue((Integer)(value));
     }
   }
 }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/RoleEligibleTradeType.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/RoleEligibleTradeType.java
@@ -45,9 +45,9 @@ public enum RoleEligibleTradeType {
     return String.valueOf(value);
   }
 
-  public static RoleEligibleTradeType fromValue(String text) {
+  public static RoleEligibleTradeType fromValue(Integer input) {
     for (RoleEligibleTradeType b : RoleEligibleTradeType.values()) {
-      if (String.valueOf(b.value).equals(text)) {
+      if (b.value.equals(input)) {
         return b;
       }
     }
@@ -57,13 +57,13 @@ public enum RoleEligibleTradeType {
   public static class Adapter extends TypeAdapter<RoleEligibleTradeType> {
     @Override
     public void write(final JsonWriter jsonWriter, final RoleEligibleTradeType enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      jsonWriter.value(String.valueOf(enumeration.getValue()));
     }
 
     @Override
     public RoleEligibleTradeType read(final JsonReader jsonReader) throws IOException {
       Object value = jsonReader.nextInt();
-      return RoleEligibleTradeType.fromValue(String.valueOf(value));
+      return RoleEligibleTradeType.fromValue((Integer)(value));
     }
   }
 }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/RolePermissionInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/RolePermissionInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * RolePermissionInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class RolePermissionInfo {
   @SerializedName("roleId")
   private Integer roleId = null;
@@ -134,7 +134,7 @@ public class RolePermissionInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -173,7 +173,7 @@ public class RolePermissionInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ServiceProfile.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ServiceProfile.java
@@ -27,7 +27,7 @@ import java.util.List;
  * ServiceProfile
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class ServiceProfile {
   @SerializedName("serviceId")
   private Integer serviceId = null;
@@ -102,7 +102,7 @@ public class ServiceProfile {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -137,7 +137,7 @@ public class ServiceProfile {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/SiteDetail.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/SiteDetail.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * SiteDetail
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class SiteDetail {
   @SerializedName("siteId")
   private Integer siteId = null;
@@ -50,7 +50,7 @@ public class SiteDetail {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class SiteDetail {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/SiteDetailInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/SiteDetailInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * SiteDetailInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class SiteDetailInfo {
   @SerializedName("siteId")
   private Integer siteId = null;
@@ -71,7 +71,7 @@ public class SiteDetailInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class SiteDetailInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserContactInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserContactInfo.java
@@ -30,7 +30,7 @@ import uk.gov.ccs.swagger.sso.model.UserDetailInfo;
  * UserContactInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserContactInfo {
   @SerializedName("contactPointReason")
   private String contactPointReason = null;
@@ -189,7 +189,7 @@ public class UserContactInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -232,7 +232,7 @@ public class UserContactInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserContactInfoList.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserContactInfoList.java
@@ -29,7 +29,7 @@ import uk.gov.ccs.swagger.sso.model.UserDetailInfo;
  * UserContactInfoList
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserContactInfoList {
   @SerializedName("detail")
   private UserDetailInfo detail = null;
@@ -83,7 +83,7 @@ public class UserContactInfoList {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -116,7 +116,7 @@ public class UserContactInfoList {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserDetailInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserDetailInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * UserDetailInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserDetailInfo {
   @SerializedName("userId")
   private String userId = null;
@@ -71,7 +71,7 @@ public class UserDetailInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class UserDetailInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserEditResponseInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserEditResponseInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * UserEditResponseInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserEditResponseInfo {
   @SerializedName("userId")
   private String userId = null;
@@ -71,7 +71,7 @@ public class UserEditResponseInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class UserEditResponseInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserIdentityProviderInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserIdentityProviderInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * UserIdentityProviderInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserIdentityProviderInfo {
   @SerializedName("identityProviderId")
   private Integer identityProviderId = null;
@@ -92,7 +92,7 @@ public class UserIdentityProviderInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -127,7 +127,7 @@ public class UserIdentityProviderInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserListInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserListInfo.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * UserListInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserListInfo {
   @SerializedName("name")
   private String name = null;
@@ -71,7 +71,7 @@ public class UserListInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -104,7 +104,7 @@ public class UserListInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserListResponse.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserListResponse.java
@@ -28,7 +28,7 @@ import uk.gov.ccs.swagger.sso.model.UserListInfo;
  * UserListResponse
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserListResponse {
   @SerializedName("currentPage")
   private Integer currentPage = null;
@@ -145,7 +145,7 @@ public class UserListResponse {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -184,7 +184,7 @@ public class UserListResponse {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserProfileEditRequestInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserProfileEditRequestInfo.java
@@ -27,7 +27,7 @@ import uk.gov.ccs.swagger.sso.model.UserTitle;
  * UserProfileEditRequestInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserProfileEditRequestInfo {
   @SerializedName("userName")
   private String userName = null;
@@ -241,7 +241,7 @@ public class UserProfileEditRequestInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -290,7 +290,7 @@ public class UserProfileEditRequestInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserProfileResponseInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserProfileResponseInfo.java
@@ -27,7 +27,7 @@ import uk.gov.ccs.swagger.sso.model.UserTitle;
  * UserProfileResponseInfo
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserProfileResponseInfo {
   @SerializedName("userName")
   private String userName = null;
@@ -241,7 +241,7 @@ public class UserProfileResponseInfo {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -290,7 +290,7 @@ public class UserProfileResponseInfo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserRequestDetail.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserRequestDetail.java
@@ -27,7 +27,7 @@ import java.util.List;
  * UserRequestDetail
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserRequestDetail {
   @SerializedName("id")
   private Integer id = null;
@@ -139,7 +139,7 @@ public class UserRequestDetail {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -176,7 +176,7 @@ public class UserRequestDetail {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserResponseDetail.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserResponseDetail.java
@@ -30,7 +30,7 @@ import uk.gov.ccs.swagger.sso.model.UserIdentityProviderInfo;
  * UserResponseDetail
  */
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2021-12-07T09:38:21.309374Z[Europe/London]")
+
 public class UserResponseDetail {
   @SerializedName("id")
   private Integer id = null;
@@ -163,7 +163,7 @@ public class UserResponseDetail {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -202,7 +202,7 @@ public class UserResponseDetail {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserTitle.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserTitle.java
@@ -48,9 +48,9 @@ public enum UserTitle {
     return String.valueOf(value);
   }
 
-  public static UserTitle fromValue(String text) {
+  public static UserTitle fromValue(Integer input) {
     for (UserTitle b : UserTitle.values()) {
-      if (String.valueOf(b.value).equals(text)) {
+      if (b.value.equals(input)) {
         return b;
       }
     }
@@ -60,13 +60,13 @@ public enum UserTitle {
   public static class Adapter extends TypeAdapter<UserTitle> {
     @Override
     public void write(final JsonWriter jsonWriter, final UserTitle enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      jsonWriter.value(String.valueOf(enumeration.getValue()));
     }
 
     @Override
     public UserTitle read(final JsonReader jsonReader) throws IOException {
       Object value = jsonReader.nextInt();
-      return UserTitle.fromValue(String.valueOf(value));
+      return UserTitle.fromValue((Integer)(value));
     }
   }
 }


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/CON-2601

As a prerequisite to moving to a more recent version of the API spec.

Only one fix needed - the generated code no longer converts the title to an `Integer`, so we need to do it ourselves.

Once this is in, we can move to a more recent version of the spec in the next PR.