### PR TITLE
CON-2601: Reinstate old title behaviour

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
@@ -37,7 +37,9 @@ public class UserService {
     private UserProfileEditRequestInfo populateUserProfileInfo(User user, String organisationId, Integer identityProvideId, List<Integer> roleIds) {
 
         UserProfileEditRequestInfo userDto = new UserProfileEditRequestInfo();
-        userDto.setTitle(fromValue(Integer.valueOf(user.getTitle())));
+        try {
+            userDto.setTitle(fromValue(Integer.valueOf(user.getTitle())));
+        } catch (NumberFormatException ignored) {}
         userDto.setFirstName(user.getFirstName());
         userDto.setLastName(user.getLastName());
         userDto.setUserName(user.getEmail());


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/CON-2601

In 5abb1b3a6383bb752b186a163015f834450498ae I had to move the title parsing logic out of the autogenerated code. However, I made a mistake - I didn't match the previous behaviour. Previously, if the title wasn't an integer, it would be set to null. Reinstate this behaviour.

It's not the right behaviour, but we'll fix that shortly.