### PR TITLE
Exclude autogenerated code from codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+version: "2"
+exclude_patterns:
+  - src/main/java/uk/gov/ccs/swagger


### PR DESCRIPTION
It's autogenerated, so there's no point in getting codeclimate to review it.