### PR TITLE
CON-2641: Manually construct bad request response

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/controller/DataMigrationApiController.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/controller/DataMigrationApiController.java
@@ -13,6 +13,7 @@ import uk.gov.ccs.swagger.dataMigration.api.DataMigrationApi;
 import uk.gov.ccs.swagger.dataMigration.model.Organisation;
 import uk.gov.ccs.swagger.dataMigration.model.Summary;
 
+import javax.validation.ConstraintViolationException;
 import java.util.List;
 
 @RestController
@@ -31,8 +32,10 @@ public class DataMigrationApiController implements DataMigrationApi {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ResponseStatus(value=HttpStatus.BAD_REQUEST)
-    @ExceptionHandler({javax.validation.ConstraintViolationException.class})
-    public void constraintViolation() {
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<String> constraintViolation(ConstraintViolationException exception) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(exception.getMessage());
     }
 }


### PR DESCRIPTION
It turns out we need to construct the response ourselves if we both want to have an informative body and customise the status.

The body looks like: `appMigrateOrg.body[0].schemeId: must not be null, appMigrateOrg.body[0].identifierId: must not be null`