### PR TITLE
CON-2464: Support user contact fields being null

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
@@ -33,9 +33,9 @@ public class ContactService {
     void migrateUserContact(User user, String userId, Org organisation) throws DataMigrationException {
         ContactPoint userContactPoint = new ContactPoint();
         userContactPoint.setEmail(stripToEmpty(user.getContactEmail()));
-        userContactPoint.setFaxNumber(user.getContactFax().replaceAll("(-| |\\(|\\))", ""));
-        userContactPoint.setTelephone(user.getContactPhone().replaceAll("(-| |\\(|\\))", ""));
-        userContactPoint.setMobile(user.getContactMobile().replaceAll("(-| |\\(|\\))", ""));
+        userContactPoint.setFaxNumber(stripToEmpty(user.getContactFax()).replaceAll("(-| |\\(|\\))", ""));
+        userContactPoint.setTelephone(stripToEmpty(user.getContactPhone()).replaceAll("(-| |\\(|\\))", ""));
+        userContactPoint.setMobile(stripToEmpty(user.getContactMobile()).replaceAll("(-| |\\(|\\))", ""));
         userContactPoint.setUri(stripToEmpty(user.getContactSocial()));
         if (isContactDetailPresent(userContactPoint)) {
             try {

--- a/src/main/resources/dm_api.yaml
+++ b/src/main/resources/dm_api.yaml
@@ -134,22 +134,27 @@ components:
           type: string
           description: User Contact Email. Only applied for new users. Blank treated as null.
           example: abc@somewhere.org
+          nullable: true
         contactMobile:
           type: string
           description: User Contact Mobile. Only applied for new users. Blank treated as null.
           example: 07956111111
+          nullable: true
         contactPhone:
           type: string
           description: User Contact Telephone. Only applied for new users. Blank treated as null.
           example: 020 8555 0000
+          nullable: true
         contactFax:
           type: string
           description: User Contact Fax. Only applied for new users. Blank treated as null.
           example: 020 8555 0001
+          nullable: true
         contactSocial:
           type: string
           description: User Contact Social. Only applied for new users. Blank treated as null.
           example: http://www.linkedin.com/
+          nullable: true
         userRoles:
           type: array
           items:
@@ -270,3 +275,4 @@ components:
         - Doctor
         - Unspecified
       default: Unspecified
+      nullable: true

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
@@ -1,0 +1,28 @@
+package uk.gov.ccs.conclave.data.migration.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ccs.conclave.data.migration.client.ConclaveClient;
+import uk.gov.ccs.conclave.data.migration.domain.Org;
+import uk.gov.ccs.swagger.dataMigration.model.User;
+
+@ExtendWith(MockitoExtension.class)
+public class ContactServiceTest {
+
+    @Mock
+    private ConclaveClient conclaveClient;
+
+    @Mock
+    private ErrorService errorService;
+
+    @InjectMocks
+    private ContactService contactService;
+
+    @Test
+    public void testMigrateUserWithNullFields() throws Exception {
+        contactService.migrateUserContact(new User(), "userId", new Org());
+    }
+}


### PR DESCRIPTION
This is the intended behaviour. This will make it easier to test these fields as we make them functional.