### PR TITLE
CON-2464: add support for contact details

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import uk.gov.ccs.conclave.data.migration.exception.DataMigrationException;
 import uk.gov.ccs.conclave.data.migration.client.ConclaveClient;
 import uk.gov.ccs.conclave.data.migration.domain.Org;
+import uk.gov.ccs.conclave.data.migration.exception.DataMigrationException;
 import uk.gov.ccs.swagger.cii.model.ContactPoint;
 import uk.gov.ccs.swagger.cii.model.OrgMigration;
 import uk.gov.ccs.swagger.dataMigration.model.Organisation;
@@ -17,8 +17,10 @@ import uk.gov.ccs.swagger.sso.model.ContactRequestInfo;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringUtils.*;
-import static uk.gov.ccs.conclave.data.migration.service.ErrorService.*;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.stripToEmpty;
+import static uk.gov.ccs.conclave.data.migration.service.ErrorService.SSO_ORG_CONTACT_ERROR_MESSAGE;
+import static uk.gov.ccs.conclave.data.migration.service.ErrorService.SSO_USER_CONTACT_ERROR_MESSAGE;
 
 @Service
 @RequiredArgsConstructor
@@ -61,24 +63,33 @@ public class ContactService {
     }
 
     private boolean isContactDetailPresent(ContactPoint contactPoint) {
-        return (isNotEmpty(contactPoint.getName()))
-                || isNotEmpty(contactPoint.getEmail())
-                || isNotEmpty(contactPoint.getTelephone())
-                || isNotEmpty(contactPoint.getMobile())
-                || isNotEmpty(contactPoint.getFaxNumber())
-                || isNotEmpty(contactPoint.getUri());
+        return (isNotEmpty(contactPoint.getName()) &&
+                  (isNotEmpty(contactPoint.getEmail())
+                    || isNotEmpty(contactPoint.getTelephone())
+                    || isNotEmpty(contactPoint.getMobile())
+                    || isNotEmpty(contactPoint.getFaxNumber())
+                    || isNotEmpty(contactPoint.getUri())));
     }
 
     private ContactRequestInfo buildContactRequestInfo(ContactPoint contactPoint) {
-
         ContactRequestInfo contactRequestInfo = new ContactRequestInfo();
         contactRequestInfo.setContactPointName(contactPoint.getName());
         List<ContactRequestDetail> contacts = new ArrayList<>();
-        contacts.add(buildContactRequestDetail("EMAIL", contactPoint.getEmail()));
-        contacts.add(buildContactRequestDetail("PHONE", contactPoint.getTelephone()));
-        contacts.add(buildContactRequestDetail("MOBILE", contactPoint.getMobile()));
-        contacts.add(buildContactRequestDetail("FAX", contactPoint.getFaxNumber()));
-        contacts.add(buildContactRequestDetail("WEB_ADDRESS", contactPoint.getUri()));
+        if (isNotEmpty(contactPoint.getEmail())) {
+            contacts.add(buildContactRequestDetail("EMAIL", contactPoint.getEmail()));
+        }
+        if (isNotEmpty(contactPoint.getTelephone())) {
+            contacts.add(buildContactRequestDetail("PHONE", contactPoint.getTelephone()));
+        }
+        if (isNotEmpty(contactPoint.getMobile())) {
+            contacts.add(buildContactRequestDetail("MOBILE", contactPoint.getMobile()));
+        }
+        if (isNotEmpty(contactPoint.getFaxNumber())) {
+            contacts.add(buildContactRequestDetail("FAX", contactPoint.getFaxNumber()));
+        }
+        if (isNotEmpty(contactPoint.getUri())) {
+            contacts.add(buildContactRequestDetail("WEB_ADDRESS", contactPoint.getUri()));
+        }
         contactRequestInfo.setContacts(contacts);
 
         return contactRequestInfo;

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
@@ -72,34 +72,25 @@ public class ContactService {
     }
 
     private ContactRequestInfo buildContactRequestInfo(ContactPoint contactPoint) {
-        ContactRequestInfo contactRequestInfo = new ContactRequestInfo();
-        contactRequestInfo.setContactPointName(contactPoint.getName());
+        ContactRequestInfo contactRequestInfo = new ContactRequestInfo().contactPointName(contactPoint.getName());
         List<ContactRequestDetail> contacts = new ArrayList<>();
         if (isNotEmpty(contactPoint.getEmail())) {
-            contacts.add(buildContactRequestDetail("EMAIL", contactPoint.getEmail()));
+            contacts.add(new ContactRequestDetail().contactType("EMAIL").contactValue(contactPoint.getEmail()));
         }
         if (isNotEmpty(contactPoint.getTelephone())) {
-            contacts.add(buildContactRequestDetail("PHONE", contactPoint.getTelephone()));
+            contacts.add(new ContactRequestDetail().contactType("PHONE").contactValue(contactPoint.getTelephone()));
         }
         if (isNotEmpty(contactPoint.getMobile())) {
-            contacts.add(buildContactRequestDetail("MOBILE", contactPoint.getMobile()));
+            contacts.add(new ContactRequestDetail().contactType("MOBILE").contactValue(contactPoint.getMobile()));
         }
         if (isNotEmpty(contactPoint.getFaxNumber())) {
-            contacts.add(buildContactRequestDetail("FAX", contactPoint.getFaxNumber()));
+            contacts.add(new ContactRequestDetail().contactType("FAX").contactValue(contactPoint.getFaxNumber()));
         }
         if (isNotEmpty(contactPoint.getUri())) {
-            contacts.add(buildContactRequestDetail("WEB_ADDRESS", contactPoint.getUri()));
+            contacts.add(new ContactRequestDetail().contactType("WEB_ADDRESS").contactValue(contactPoint.getUri()));
         }
         contactRequestInfo.setContacts(contacts);
 
         return contactRequestInfo;
-
-    }
-
-    private ContactRequestDetail buildContactRequestDetail(String name, String value) {
-        ContactRequestDetail contactRequestDetail = new ContactRequestDetail();
-        contactRequestDetail.setContactType(name);
-        contactRequestDetail.setContactValue(value);
-        return contactRequestDetail;
     }
 }

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
@@ -31,15 +31,17 @@ public class ContactService {
     private static final Logger log = LoggerFactory.getLogger(ContactService.class);
 
     void migrateUserContact(User user, String userId, Org organisation) throws DataMigrationException {
-        ContactPoint userContactPoint = new ContactPoint();
-        userContactPoint.setEmail(stripToEmpty(user.getContactEmail()));
-        userContactPoint.setFaxNumber(stripToEmpty(user.getContactFax()).replaceAll("(-| |\\(|\\))", ""));
-        userContactPoint.setTelephone(stripToEmpty(user.getContactPhone()).replaceAll("(-| |\\(|\\))", ""));
-        userContactPoint.setMobile(stripToEmpty(user.getContactMobile()).replaceAll("(-| |\\(|\\))", ""));
-        userContactPoint.setUri(stripToEmpty(user.getContactSocial()));
-        if (isContactDetailPresent(userContactPoint)) {
+        ContactPoint ciiUserContactPoint = new ContactPoint()
+                .name(user.getContactName())
+                .email(stripToEmpty(user.getContactEmail()))
+                .faxNumber(stripToEmpty(user.getContactFax()).replaceAll("(-| |\\(|\\))", ""))
+                .telephone(stripToEmpty(user.getContactPhone()).replaceAll("(-| |\\(|\\))", ""))
+                .mobile(stripToEmpty(user.getContactMobile()).replaceAll("(-| |\\(|\\))", ""))
+                .uri(stripToEmpty(user.getContactSocial()));
+
+        if (isContactDetailPresent(ciiUserContactPoint)) {
             try {
-                conclaveClient.createUserContact(userId, buildContactRequestInfo(userContactPoint));
+                conclaveClient.createUserContact(userId, buildContactRequestInfo(ciiUserContactPoint));
             } catch (uk.gov.ccs.swagger.sso.ApiException e) {
                 log.error("{}{}: {}", SSO_USER_CONTACT_ERROR_MESSAGE, e.getMessage(), e.getResponseBody());
                 errorService.saveUserDetailWithStatusCode(user, SSO_USER_CONTACT_ERROR_MESSAGE + e.getMessage(), e.getCode(), organisation);

--- a/src/main/java/uk/gov/ccs/swagger/dataMigration/model/User.java
+++ b/src/main/java/uk/gov/ccs/swagger/dataMigration/model/User.java
@@ -31,6 +31,9 @@ public class User   {
   @JsonProperty("lastName")
   private String lastName = null;
 
+  @JsonProperty("contactName")
+  private String contactName = null;
+
   @JsonProperty("contactEmail")
   private String contactEmail = null;
 
@@ -128,6 +131,25 @@ public class User   {
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
+  }
+
+  public User contactName(String contactName) {
+    this.contactName = contactName;
+    return this;
+  }
+
+  /**
+   * User Contact Email. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.
+   * @return contactName
+   **/
+  @Schema(example = "Joe Bloggs", description = "User Contact Email. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.")
+  
+    public String getContactName() {
+    return contactName;
+  }
+
+  public void setContactName(String contactName) {
+    this.contactName = contactName;
   }
 
   public User contactEmail(String contactEmail) {
@@ -266,6 +288,7 @@ public class User   {
         Objects.equals(this.title, user.title) &&
         Objects.equals(this.firstName, user.firstName) &&
         Objects.equals(this.lastName, user.lastName) &&
+        Objects.equals(this.contactName, user.contactName) &&
         Objects.equals(this.contactEmail, user.contactEmail) &&
         Objects.equals(this.contactMobile, user.contactMobile) &&
         Objects.equals(this.contactPhone, user.contactPhone) &&
@@ -276,7 +299,7 @@ public class User   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, title, firstName, lastName, contactEmail, contactMobile, contactPhone, contactFax, contactSocial, userRoles);
+    return Objects.hash(email, title, firstName, lastName, contactName, contactEmail, contactMobile, contactPhone, contactFax, contactSocial, userRoles);
   }
 
   @Override
@@ -288,6 +311,7 @@ public class User   {
     sb.append("    title: ").append(toIndentedString(title)).append("\n");
     sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
     sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+    sb.append("    contactName: ").append(toIndentedString(contactName)).append("\n");
     sb.append("    contactEmail: ").append(toIndentedString(contactEmail)).append("\n");
     sb.append("    contactMobile: ").append(toIndentedString(contactMobile)).append("\n");
     sb.append("    contactPhone: ").append(toIndentedString(contactPhone)).append("\n");

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/ContactRequestInfo.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/ContactRequestInfo.java
@@ -66,7 +66,7 @@ public class ContactRequestInfo {
    * Get contactPointName
    * @return contactPointName
   **/
-  @Schema(description = "")
+  @Schema(required = true, description = "")
   public String getContactPointName() {
     return contactPointName;
   }

--- a/src/main/resources/conclave_api.yaml
+++ b/src/main/resources/conclave_api.yaml
@@ -3138,7 +3138,8 @@
           },
           "contactPointName": {
             "type": "string",
-            "nullable": true
+            "nullable": false,
+            "minLength": 1
           },
           "contacts": {
             "type": "array",
@@ -3148,6 +3149,7 @@
             "nullable": true
           }
         },
+        "required": ["contactPointName"],
         "additionalProperties": false
       },
       "ContactResponseDetail": {

--- a/src/main/resources/dm_api.yaml
+++ b/src/main/resources/dm_api.yaml
@@ -130,6 +130,11 @@ components:
           type: string
           description: Last Name
           example: Bloggs
+        contactName:
+          type: string
+          description: User Contact Email. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.
+          example: Joe Bloggs
+          nullable: true
         contactEmail:
           type: string
           description: User Contact Email. Only applied for new users. Blank treated as null.

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
@@ -2,12 +2,20 @@ package uk.gov.ccs.conclave.data.migration.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.ccs.conclave.data.migration.client.ConclaveClient;
 import uk.gov.ccs.conclave.data.migration.domain.Org;
 import uk.gov.ccs.swagger.dataMigration.model.User;
+import uk.gov.ccs.swagger.sso.model.ContactRequestInfo;
+import uk.gov.ccs.swagger.sso.model.OrganisationRoleUpdate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 public class ContactServiceTest {
@@ -22,7 +30,22 @@ public class ContactServiceTest {
     private ContactService contactService;
 
     @Test
-    public void testMigrateUserWithNullFields() throws Exception {
+    public void testMigrateUserWithNoContact() throws Exception {
         contactService.migrateUserContact(new User(), "userId", new Org());
+
+        verifyNoInteractions(conclaveClient);
+    }
+
+    @Test
+    public void testMigrateUserWithFullContact() throws Exception {
+        contactService.migrateUserContact(
+                new User().contactName("name").contactEmail("email").contactFax("fax").contactPhone("phone").contactMobile("mobile").contactSocial("social"), "userId",
+                new Org()
+        );
+
+        ArgumentCaptor<ContactRequestInfo> argumentCaptor = ArgumentCaptor.forClass(ContactRequestInfo.class);
+        verify(conclaveClient).createUserContact(eq("userId"), argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getContactPointName()).isEqualTo("name");
+        assertThat(argumentCaptor.getValue().getContacts().size()).isEqualTo(5);
     }
 }

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
@@ -37,6 +37,13 @@ public class ContactServiceTest {
     }
 
     @Test
+    public void testMigrateUserWithNoContactName() throws Exception {
+        contactService.migrateUserContact(new User().contactSocial("social"), "userId", new Org());
+
+        verifyNoInteractions(conclaveClient);
+    }
+
+    @Test
     public void testMigrateUserWithPartialContact() throws Exception {
         contactService.migrateUserContact(new User().contactName("name").contactSocial("social"), "userId", new Org());
 

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
@@ -37,6 +37,18 @@ public class ContactServiceTest {
     }
 
     @Test
+    public void testMigrateUserWithPartialContact() throws Exception {
+        contactService.migrateUserContact(new User().contactName("name").contactSocial("social"), "userId", new Org());
+
+        ArgumentCaptor<ContactRequestInfo> argumentCaptor = ArgumentCaptor.forClass(ContactRequestInfo.class);
+        verify(conclaveClient).createUserContact(eq("userId"), argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getContactPointName()).isEqualTo("name");
+        assertThat(argumentCaptor.getValue().getContacts().size()).isEqualTo(1);
+        assertThat(argumentCaptor.getValue().getContacts().get(0).getContactType()).isEqualTo("WEB_ADDRESS");
+        assertThat(argumentCaptor.getValue().getContacts().get(0).getContactValue()).isEqualTo("social");
+    }
+
+    @Test
     public void testMigrateUserWithFullContact() throws Exception {
         contactService.migrateUserContact(
                 new User().contactName("name").contactEmail("email").contactFax("fax").contactPhone("phone").contactMobile("mobile").contactSocial("social"), "userId",


### PR DESCRIPTION
When adding contact details to an organisation or user, we now need to provide a `contactPointName`. Add this to the DM API and make it required to add the contact details.

There are some known issues that I'll resolve in future PRs once we know what we want:
1. what should the field be called in the DM API?
2. what should we do if `contactPointName` is missing?
3. should we add contact details if the user already exists (we don't currently)