### PR TITLE
Revert "CON-2646: Add user contact name to database"

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/domain/User.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/domain/User.java
@@ -24,8 +24,6 @@ public class User {
 
     private String lastName;
 
-    private String contactName;
-
     private String contactEmail;
 
     private String contactMobile;

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
@@ -111,7 +111,6 @@ public class ErrorService {
         if (isNotEmpty(userRoles)) {
             user.setUserRoles(userRolesAsString(userRoles));
         }
-        user.setContactName(u.getContactName());
         user.setContactEmail(u.getContactEmail());
         user.setContactMobile(u.getContactMobile());
         user.setContactPhone(u.getContactPhone());

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -72,9 +72,4 @@
     <changeSet author="janice.alvares (generated)" id="1632300211382-7">
         <addForeignKeyConstraint baseColumnNames="org_id" baseTableName="users" constraintName="fkhvruj9y6lvjrje2lvgbftekbw" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="org_id" referencedTableName="org"/>
     </changeSet>
-    <changeSet author="benjamin.gill" id="1632300211382-8">
-        <addColumn tableName="users">
-            <column name="contact_name" type="VARCHAR(255)"/>
-        </addColumn>
-    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ErrorServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ErrorServiceTest.java
@@ -35,7 +35,7 @@ public class ErrorServiceTest {
     @Test
     public void testSuccessfullySaveUser() throws Exception {
         errorService.saveUserDetailWithStatusCode(
-                new User().email("email").firstName("first").lastName("last").title(UserTitle.DOCTOR).contactName("name").contactEmail("email").contactFax("fax").contactPhone("phone").contactMobile("mobile").contactSocial("social"),
+                new User().email("email").firstName("first").lastName("last").title(UserTitle.DOCTOR).contactFax("fax"),
                 "message",
                 200,
                 new Org()
@@ -47,11 +47,6 @@ public class ErrorServiceTest {
         assertThat(argumentCaptor.getValue().getFirstName()).isEqualTo("first");
         assertThat(argumentCaptor.getValue().getLastName()).isEqualTo("last");
         assertThat(argumentCaptor.getValue().getTitle()).isEqualTo("Doctor");
-        assertThat(argumentCaptor.getValue().getContactName()).isEqualTo("name");
-        assertThat(argumentCaptor.getValue().getContactEmail()).isEqualTo("email");
         assertThat(argumentCaptor.getValue().getContactFax()).isEqualTo("fax");
-        assertThat(argumentCaptor.getValue().getContactPhone()).isEqualTo("phone");
-        assertThat(argumentCaptor.getValue().getContactMobile()).isEqualTo("mobile");
-        assertThat(argumentCaptor.getValue().getContactSocial()).isEqualTo("social");
     }
 }


### PR DESCRIPTION
Reverts Crown-Commercial-Service/ccs-conclave-data-migration#264

It turns out that the migration isn't automatically applied. I need to work out how to do that, and then retry.

`2022-07-05T10:56:06.73+0100 [APP/PROC/WEB/0] OUT 2022-07-05 09:56:06.739 ERROR 13 --- [nio-8080-exec-5] o.h.engine.jdbc.spi.SqlExceptionHelper   : ERROR: column "contact_name" of relation "users" does not exist`