### PR TITLE
CON-2713: Create script to run non-production database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ java -jar swagger-codegen-cli.jar generate --output . --config src/main/resource
 java -jar swagger-codegen-cli.jar generate --output . --config src/main/resources/conclave_config.json --input-spec src/main/resources/conclave_api.yaml --lang java
 java -jar swagger-codegen-cli.jar generate --output . --config src/main/resources/dm_config.json --input-spec src/main/resources/dm_api.yaml --lang spring
 ```
+
+## Database migrations
+
+We use [liquibase](https://docs.liquibase.com/home.html) to manage the database. Migrations are defined in [`master.xml`](src/main/resources/db/changelog/master.xml).
+
+We do not yet know how to run the database migrations securely in production. We have a less secure process you can use in other environments:
+
+1. Install liquibase: `brew install liquibase`
+2. Install the conduit plugin for Cloudfoundry: `cf install-plugin conduit`
+3. Find the name of the database service in your chosen non-production environment
+4. Run `cf conduit <database service name> -- ./run-db-migrations.sh`

--- a/run-db-migrations.sh
+++ b/run-db-migrations.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+# Because we're disabling SSL for the connection, so are vulnerable to man-in-the-middle attacks.
+echo "This script is not secure. Don't use it in production"
+
+liquibase update \
+  --changelog-file src/main/resources/db/changelog/master.xml \
+  --defaults-file src/main/resources/liquibase.properties \
+  --url "$(jq -nr 'env.VCAP_SERVICES | fromjson | .postgres[].Credentials.jdbcuri')&ssl=false"

--- a/src/main/resources/liquibase.properties
+++ b/src/main/resources/liquibase.properties
@@ -1,4 +1,2 @@
-url=url
-username=username
-password=password
-changeLogFile=src/main/resources/db/create-report.xml
+liquibase.hub.mode=off
+liquibase.showBanner=false


### PR DESCRIPTION
After a lot of fiddling, I've worked out how to get liquibase to do what we want. Unfortunately, this requires disabling SSL. It seems as if the SSL key the database is using a root certificate my copy of liquibase doesn't recognise. This isn't good. However, it's still useful for non-production environments in the interim.