### PR TITLE
CON-2452: handle nullable lists

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
@@ -185,6 +185,9 @@ public class OrganisationService {
     }
 
     private Boolean checkForAdminOnNewOrg(final Organisation organisation) {
+        if (organisation == null || organisation.getUser() == null) {
+            return false;
+        }
 
         for (User users : organisation.getUser()) {
             System.out.println(String.format("HERE -> A (user):  %s", users));

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
@@ -182,7 +182,7 @@ public class OrganisationService {
         return identityProviderId;
     }
 
-    private Boolean hasOrganisationAdmin(final Organisation organisation) {
+    private static boolean hasOrganisationAdmin(final Organisation organisation) {
         if (organisation == null || organisation.getUser() == null) {
             return false;
         }

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
@@ -191,6 +191,9 @@ public class OrganisationService {
 
         for (User users : organisation.getUser()) {
             System.out.println(String.format("HERE -> A (user):  %s", users));
+            if (users.getUserRoles() == null) {
+                continue;
+            }
             for (UserRole userRole : users.getUserRoles()) {
                 System.out.println(String.format("HERE -> B (userRole):  %s", userRole));
                 System.out.println(String.format("HERE -> C (userRole.getName()):  %s", userRole.getName()));

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
@@ -81,22 +81,21 @@ public class OrganisationService {
 
 
     private void migrateOrgToConclave(OrgMigration ciiResponse, Organisation org) throws DataMigrationException {
-        System.out.println(String.format("HERE -> 10 (org):  %s", org));
-        System.out.println(String.format("HERE -> 11 (hasOrganisationAdmin(org)):  %s", hasOrganisationAdmin(org)));
-        System.out.println(String.format("HERE -> 12 (isNewOrg(ciiResponse)):  %s", isNewOrg(ciiResponse)));
-        System.out.println(String.format("HERE -> 13 (org.getUser()):  %s", org.getUser()));
+        log.debug("Migrating organisation to conclave: {}", org);
 
         try {
             String organisationId = ciiResponse.getOrganisationId();
             if (isNewOrg(ciiResponse) && !hasOrganisationAdmin(org)) {
+                log.debug("Deleting new organisation without admin");
                 deleteOrganisation(organisationId);
-                System.out.println(String.format("HERE -> 14 DELETING ORG"));
             } else if (isNewOrg(ciiResponse)) {
+                log.debug("Migrating new organisation with admin");
                 OrganisationProfileInfo conclaveOrgProfile = buildOrgProfileRequest(ciiResponse, org);
                 conclaveClient.createConclaveOrg(conclaveOrgProfile);
                 contactService.migrateOrgContact(org, ciiResponse, organisationId);
                 roleService.applyOrganisationRole(organisationId, org);
             } else {
+                log.debug("Organisation already exists. Applying roles");
                 roleService.applyOrganisationRole(organisationId, org);
             }
 

--- a/src/main/resources/dm_api.yaml
+++ b/src/main/resources/dm_api.yaml
@@ -106,10 +106,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OrgRole'
+          nullable: True
         user:
           type: array
           items:
             $ref: '#/components/schemas/User'
+          nullable: True
       required:
         - identifier-id
         - scheme-id
@@ -164,6 +166,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/UserRole'
+          nullable: True
       required:
         - email
         - firstName

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/OrganisationServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/OrganisationServiceTest.java
@@ -83,7 +83,7 @@ public class OrganisationServiceTest {
         given(ciiOrgClient.createCiiOrganisation(any(), any())).willReturn(new OrgMigration().identifier(new Identifier()).address(new Address()).organisationId("org_id"));
         given(conclaveClient.getIdentityProviderId(any())).willReturn(1);
 
-        organisationService.migrateOrganisation(new Organisation().user(List.of()));
+        organisationService.migrateOrganisation(new Organisation());
 
         verify(ciiOrgClient).deleteCiiOrganisation(eq("org_id"));
     }

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/OrganisationServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/OrganisationServiceTest.java
@@ -87,4 +87,12 @@ public class OrganisationServiceTest {
 
         verify(ciiOrgClient).deleteCiiOrganisation(eq("org_id"));
     }
+
+    @Test
+    public void shouldHandleNullRoles() throws Exception {
+        given(ciiOrgClient.createCiiOrganisation(any(), any())).willReturn(new OrgMigration().identifier(new Identifier()).address(new Address()));
+        given(conclaveClient.getIdentityProviderId(any())).willReturn(1);
+
+        organisationService.migrateOrganisation(new Organisation().user(List.of(new User())));
+    }
 }


### PR DESCRIPTION
Check for lists being null before we use them.

There are three lists that can be null. I've checked all three. Two had unit tests that covered all their uses where they could be null, so no action was needed. However, there were a bunch of potential NullPointerExceptions in handling user roles. So I fixed that up, refactored to make it clearer, and updated the unit tests accordingly.