### PR TITLE
Include request ID in logs

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/controller/DataMigrationApiController.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/controller/DataMigrationApiController.java
@@ -3,10 +3,10 @@ package uk.gov.ccs.conclave.data.migration.controller;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.ccs.conclave.data.migration.service.MigrationService;
 import uk.gov.ccs.swagger.dataMigration.api.DataMigrationApi;
@@ -15,6 +15,7 @@ import uk.gov.ccs.swagger.dataMigration.model.Summary;
 
 import javax.validation.ConstraintViolationException;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,10 +27,15 @@ public class DataMigrationApiController implements DataMigrationApi {
 
     @Override
     public ResponseEntity<List<Summary>> appMigrateOrg(String fileFormat, String docId, List<Organisation> body) {
-        log.info(" API for data migration invoked for file format " + fileFormat);
-        System.out.println(String.format("\n\n HERE -> 0 (requestbody):  %s \n\n", body));
-        migrationService.migrate(body);
-        return new ResponseEntity<>(HttpStatus.OK);
+        try {
+            MDC.put("requestId", UUID.randomUUID().toString());
+            log.info(" API for data migration invoked for file format " + fileFormat);
+            System.out.println(String.format("\n\n HERE -> 0 (requestbody):  %s \n\n", body));
+            migrationService.migrate(body);
+            return new ResponseEntity<>(HttpStatus.OK);
+        } finally {
+            MDC.clear();
+        }
     }
 
     @ExceptionHandler({ConstraintViolationException.class, IllegalArgumentException.class})


### PR DESCRIPTION
Using the Java MDC. This will allow us to separate logs from different requests if the requests overlap in time.