### PR TITLE
CON-2464: rename `contactName` to `contactPointName`

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/domain/User.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/domain/User.java
@@ -24,7 +24,7 @@ public class User {
 
     private String lastName;
 
-    private String contactName;
+    private String contactPointName;
 
     private String contactEmail;
 

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
@@ -34,7 +34,7 @@ public class ContactService {
 
     void migrateUserContact(User user, String userId, Org organisation) throws DataMigrationException {
         ContactPoint ciiUserContactPoint = new ContactPoint()
-                .name(user.getContactName())
+                .name(user.getContactPointName())
                 .email(stripToEmpty(user.getContactEmail()))
                 .faxNumber(stripToEmpty(user.getContactFax()).replaceAll("[- ()]", ""))
                 .telephone(stripToEmpty(user.getContactPhone()).replaceAll("[- ()]", ""))

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
@@ -111,7 +111,7 @@ public class ErrorService {
         if (isNotEmpty(userRoles)) {
             user.setUserRoles(userRolesAsString(userRoles));
         }
-        user.setContactName(u.getContactName());
+        user.setContactName(u.getContactPointName());
         user.setContactEmail(u.getContactEmail());
         user.setContactMobile(u.getContactMobile());
         user.setContactPhone(u.getContactPhone());

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
@@ -111,7 +111,7 @@ public class ErrorService {
         if (isNotEmpty(userRoles)) {
             user.setUserRoles(userRolesAsString(userRoles));
         }
-        user.setContactName(u.getContactPointName());
+        user.setContactPointName(u.getContactPointName());
         user.setContactEmail(u.getContactEmail());
         user.setContactMobile(u.getContactMobile());
         user.setContactPhone(u.getContactPhone());

--- a/src/main/java/uk/gov/ccs/swagger/dataMigration/model/User.java
+++ b/src/main/java/uk/gov/ccs/swagger/dataMigration/model/User.java
@@ -31,8 +31,8 @@ public class User   {
   @JsonProperty("lastName")
   private String lastName = null;
 
-  @JsonProperty("contactName")
-  private String contactName = null;
+  @JsonProperty("contactPointName")
+  private String contactPointName = null;
 
   @JsonProperty("contactEmail")
   private String contactEmail = null;
@@ -133,23 +133,23 @@ public class User   {
     this.lastName = lastName;
   }
 
-  public User contactName(String contactName) {
-    this.contactName = contactName;
+  public User contactPointName(String contactPointName) {
+    this.contactPointName = contactPointName;
     return this;
   }
 
   /**
-   * User Contact Email. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.
-   * @return contactName
+   * Name for the user's contact record. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.
+   * @return contactPointName
    **/
-  @Schema(example = "Joe Bloggs", description = "User Contact Email. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.")
+  @Schema(example = "Joe Bloggs", description = "Name for the user's contact record. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.")
   
-    public String getContactName() {
-    return contactName;
+    public String getContactPointName() {
+    return contactPointName;
   }
 
-  public void setContactName(String contactName) {
-    this.contactName = contactName;
+  public void setContactPointName(String contactPointName) {
+    this.contactPointName = contactPointName;
   }
 
   public User contactEmail(String contactEmail) {
@@ -288,7 +288,7 @@ public class User   {
         Objects.equals(this.title, user.title) &&
         Objects.equals(this.firstName, user.firstName) &&
         Objects.equals(this.lastName, user.lastName) &&
-        Objects.equals(this.contactName, user.contactName) &&
+        Objects.equals(this.contactPointName, user.contactPointName) &&
         Objects.equals(this.contactEmail, user.contactEmail) &&
         Objects.equals(this.contactMobile, user.contactMobile) &&
         Objects.equals(this.contactPhone, user.contactPhone) &&
@@ -299,7 +299,7 @@ public class User   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, title, firstName, lastName, contactName, contactEmail, contactMobile, contactPhone, contactFax, contactSocial, userRoles);
+    return Objects.hash(email, title, firstName, lastName, contactPointName, contactEmail, contactMobile, contactPhone, contactFax, contactSocial, userRoles);
   }
 
   @Override
@@ -311,7 +311,7 @@ public class User   {
     sb.append("    title: ").append(toIndentedString(title)).append("\n");
     sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
     sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
-    sb.append("    contactName: ").append(toIndentedString(contactName)).append("\n");
+    sb.append("    contactPointName: ").append(toIndentedString(contactPointName)).append("\n");
     sb.append("    contactEmail: ").append(toIndentedString(contactEmail)).append("\n");
     sb.append("    contactMobile: ").append(toIndentedString(contactMobile)).append("\n");
     sb.append("    contactPhone: ").append(toIndentedString(contactPhone)).append("\n");

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -77,4 +77,7 @@
             <column name="contact_name" type="VARCHAR(255)"/>
         </addColumn>
     </changeSet>
+    <changeSet author="benjamin.gill" id="1632300211382-9">
+        <renameColumn tableName="users" oldColumnName="contact_name" newColumnName="contact_point_name"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/dm_api.yaml
+++ b/src/main/resources/dm_api.yaml
@@ -132,9 +132,9 @@ components:
           type: string
           description: Last Name
           example: Bloggs
-        contactName:
+        contactPointName:
           type: string
-          description: User Contact Email. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.
+          description: Name for the user's contact record. Only applied for new users. Blank treated as null. Must be present and non-empty if any other contact fields are.
           example: Joe Bloggs
           nullable: true
         contactEmail:

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ContactServiceTest.java
@@ -45,7 +45,7 @@ public class ContactServiceTest {
 
     @Test
     public void testMigrateUserWithPartialContact() throws Exception {
-        contactService.migrateUserContact(new User().contactName("name").contactSocial("social"), "userId", new Org());
+        contactService.migrateUserContact(new User().contactPointName("name").contactSocial("social"), "userId", new Org());
 
         ArgumentCaptor<ContactRequestInfo> argumentCaptor = ArgumentCaptor.forClass(ContactRequestInfo.class);
         verify(conclaveClient).createUserContact(eq("userId"), argumentCaptor.capture());
@@ -58,7 +58,7 @@ public class ContactServiceTest {
     @Test
     public void testMigrateUserWithFullContact() throws Exception {
         contactService.migrateUserContact(
-                new User().contactName("name").contactEmail("email").contactFax("fax").contactPhone("phone").contactMobile("mobile").contactSocial("social"), "userId",
+                new User().contactPointName("name").contactEmail("email").contactFax("fax").contactPhone("phone").contactMobile("mobile").contactSocial("social"), "userId",
                 new Org()
         );
 
@@ -71,7 +71,7 @@ public class ContactServiceTest {
     @Test
     public void testStripUnwantedCharacters() throws Exception {
         contactService.migrateUserContact(
-                new User().contactName("name").contactFax("fax- ()").contactPhone("phone()-- ").contactMobile("mobile- (-- )("), "userId",
+                new User().contactPointName("name").contactFax("fax- ()").contactPhone("phone()-- ").contactMobile("mobile- (-- )("), "userId",
                 new Org()
         );
 

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ErrorServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ErrorServiceTest.java
@@ -35,7 +35,7 @@ public class ErrorServiceTest {
     @Test
     public void testSuccessfullySaveUser() throws Exception {
         errorService.saveUserDetailWithStatusCode(
-                new User().email("email").firstName("first").lastName("last").title(UserTitle.DOCTOR).contactName("name").contactEmail("email").contactFax("fax").contactPhone("phone").contactMobile("mobile").contactSocial("social"),
+                new User().email("email").firstName("first").lastName("last").title(UserTitle.DOCTOR).contactPointName("name").contactEmail("email").contactFax("fax").contactPhone("phone").contactMobile("mobile").contactSocial("social"),
                 "message",
                 200,
                 new Org()

--- a/src/test/java/uk/gov/ccs/conclave/data/migration/service/ErrorServiceTest.java
+++ b/src/test/java/uk/gov/ccs/conclave/data/migration/service/ErrorServiceTest.java
@@ -47,7 +47,7 @@ public class ErrorServiceTest {
         assertThat(argumentCaptor.getValue().getFirstName()).isEqualTo("first");
         assertThat(argumentCaptor.getValue().getLastName()).isEqualTo("last");
         assertThat(argumentCaptor.getValue().getTitle()).isEqualTo("Doctor");
-        assertThat(argumentCaptor.getValue().getContactName()).isEqualTo("name");
+        assertThat(argumentCaptor.getValue().getContactPointName()).isEqualTo("name");
         assertThat(argumentCaptor.getValue().getContactEmail()).isEqualTo("email");
         assertThat(argumentCaptor.getValue().getContactFax()).isEqualTo("fax");
         assertThat(argumentCaptor.getValue().getContactPhone()).isEqualTo("phone");


### PR DESCRIPTION
To match what's in PPG and the data spec. The original name was from the data template, which was wrong.

Update the column in the DM database to match.

Requires a database migration: https://docs.liquibase.com/change-types/rename-column.html