### PR TITLE
Log at INFO level in preprod and prod

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,3 +14,4 @@ applications:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ }, memory_calculator: { stack_threads: 25 } }'
       JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
       SPRING_PROFILES_ACTIVE: cloud
+      JAVA_OPTS: -Dlogging.level.uk.gov.ccs.conclave.data.migration=INFO


### PR DESCRIPTION
We've configured debug-level logging for sandbox and integration - https://github.com/Crown-Commercial-Service/ccs-conclave-data-migration/pull/272. We don't want debug logging in prod due to the risk of leaking sensitive data to the logs. And pre-prod should match prod.

So set an INFO log level in these higher environments. This should strike the appropriate balance of being sufficiently informative but not too spammy.