### PR TITLE
CON-2690: provide instructions for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ This project uses Java 11 and Maven. To run the tests, ensure that `JAVA_HOME` i
 
 CCS people can view [the internal quickstart guide](https://crowncommercialservice.atlassian.net/wiki/spaces/CON/pages/3373465612) that lists all the access and permissions you should ask for.
 
+## Run locally
+
+You can run Data Migration and its database locally. However, it needs access to Vault, CII, and SSO, which we can't run locally. So we have a script that runs the application against a local database, but using the Vault, CII, and SSO from the sandbox environment.
+
+You need to have `docker` and `cf` installed, and have access to the sandbox space in our GOV.UK PaaS organisation.
+
+1. Run `docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=test postgres:13`
+2. In another terminal window, run `./run-locally.sh`
+3. Access the application at `http://localhost:8080`
+
 ## Generating server stub and API clients
 
 The server interface and CII and SSO clients are generated using [swagger-codegen](https://github.com/swagger-api/swagger-codegen) from [OpenAPI specs](src/main/resources).

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <profiles>
+                        <profile>local</profile>
+                    </profiles>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.liquibase</groupId>

--- a/run-locally.sh
+++ b/run-locally.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eoux pipefail
+
+cf target -s sandbox
+
+liquibase update \
+  --changelog-file src/main/resources/db/changelog/master.xml \
+  --defaults-file src/main/resources/liquibase.properties \
+  --url jdbc:postgresql://localhost:5432/postgres \
+  --username postgres \
+  --password test
+
+set +x
+export VCAP_SERVICES=$(
+  cf ssh ccs-conclave-data-migration -c 'echo $VCAP_SERVICES' | jq -r '{"hashicorp-vault": ."hashicorp-vault"}'
+)
+export VAULT_TOKEN=$(
+  cf ssh ccs-conclave-data-migration -c 'echo $VAULT_TOKEN'
+)
+set -x
+
+./mvnw spring-boot:run

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,10 @@
+spring.datasource.driverClassName=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=test
+
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=create
+
+logging.level.uk.gov.ccs.conclave.data.migration=DEBUG

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -30,14 +30,14 @@
             <column name="duration" type="FLOAT8">
                 <constraints nullable="false"/>
             </column>
-            <column name="end_time" type="TIMESTAMP(29) WITHOUT TIME ZONE"/>
+            <column name="end_time" type="TIMESTAMP WITHOUT TIME ZONE"/>
             <column name="failed_users" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
             <column name="processed_users" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="start_time" type="TIMESTAMP(29) WITHOUT TIME ZONE"/>
+            <column name="start_time" type="TIMESTAMP WITHOUT TIME ZONE"/>
             <column name="status" type="VARCHAR(255)"/>
             <column name="total_organisations" type="BIGINT">
                 <constraints nullable="false"/>


### PR DESCRIPTION
I've finally worked out how to do it. It's a bit hacky, but it works - I can use the API successfully. See commits for details.

FYI @tberey - when this gets to higher environments, you'll need to run the following command to sort out the database migrations. One of the existing changesets doesn't work on postgres, so I needed to edit it, which broke the checksums (even though the change is benign)

```
liquibase clear-checksums \
  --defaults-file src/main/resources/liquibase.properties \
  --url "$(jq -nr 'env.VCAP_SERVICES | fromjson | .postgres[].Credentials.jdbcuri')&ssl=false"
```