### PR TITLE
CON-2464-Add-Contact-DB-Records-and-Update-Response-Info

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ContactService.java
@@ -67,7 +67,7 @@ public class ContactService {
         } else {
             System.out.println("\n\n HERE -> 10  REPORT ERROR TO DATABASE?!?! \n\n");
             log.error("{}: {}", SSO_USER_CONTACT_ERROR_MESSAGE, SSO_USER_CONTACT_ERROR_INFO);
-            errorService.saveUserDetailWithStatusCode(user, SSO_USER_CONTACT_ERROR_MESSAGE + SSO_USER_CONTACT_ERROR_INFO, 400, organisation);
+            errorService.saveUserDetailWithStatusCodeWithoutException(user, SSO_USER_CONTACT_ERROR_MESSAGE + SSO_USER_CONTACT_ERROR_INFO, 400, organisation);
             DataMigrationApiController.responseReport.add(SSO_USER_CONTACT_ERROR_INFO + user.getEmail());
         }
     }

--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/ErrorService.java
@@ -88,7 +88,13 @@ public class ErrorService {
         }
     }
 
-    public void saveUserDetailWithStatusCode(uk.gov.ccs.swagger.dataMigration.model.User user, String message, Integer statusCode, Org savedOrg) {
+    public void saveUserDetailWithStatusCode(uk.gov.ccs.swagger.dataMigration.model.User user, String message, Integer statusCode, Org savedOrg) throws DataMigrationException {
+        User usersSet = populateUserWithStatus(message, statusCode, savedOrg, user);
+        userRepository.save(usersSet);
+        handleFailure(message, statusCode);
+    }
+
+    public void saveUserDetailWithStatusCodeWithoutException(uk.gov.ccs.swagger.dataMigration.model.User user, String message, Integer statusCode, Org savedOrg) {
         User usersSet = populateUserWithStatus(message, statusCode, savedOrg, user);
         userRepository.save(usersSet);
     }


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2464**
Update DB entries to provide information when failing to create a Contact Record. Also relay the information in the response.