### PR TITLE
CON-2452-Update-Swagger-Spec-Mandatory-Fields

### DIFF
--- a/src/main/java/uk/gov/ccs/swagger/dataMigration/model/Organisation.java
+++ b/src/main/java/uk/gov/ccs/swagger/dataMigration/model/Organisation.java
@@ -88,7 +88,7 @@ public class Organisation   {
   @Schema(example = "true", required = true, description = "Buyer status")
       @NotNull
 
-    public String getRightToBuy() {
+  @Pattern(regexp="^([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])$")   public String getRightToBuy() {
     return rightToBuy;
   }
 

--- a/src/main/resources/dm_api.yaml
+++ b/src/main/resources/dm_api.yaml
@@ -106,6 +106,7 @@ components:
           example: GB-COH
         rightToBuy:
           type: string
+          pattern: '^([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])$'
           description: Buyer status
           example: true
         orgRoles:


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2452**
Updates swagger spec for DM, so that rightToBuy and UserRoles are mandatory fields, else a 400 is returned informing the user.