### PR TITLE
CON-2452-Update-Title-Validation-Options-Swagger

### DIFF
--- a/src/main/java/uk/gov/ccs/swagger/dataMigration/model/Organisation.java
+++ b/src/main/java/uk/gov/ccs/swagger/dataMigration/model/Organisation.java
@@ -88,7 +88,7 @@ public class Organisation   {
   @Schema(example = "true", required = true, description = "Buyer status")
       @NotNull
 
-  @Size(min=4,max=5) @Pattern(regexp="^([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])$")   public String getRightToBuy() {
+  @Pattern(regexp="^([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])$") @Size(min=4,max=5)   public String getRightToBuy() {
     return rightToBuy;
   }
 

--- a/src/main/java/uk/gov/ccs/swagger/dataMigration/model/UserTitle.java
+++ b/src/main/java/uk/gov/ccs/swagger/dataMigration/model/UserTitle.java
@@ -17,6 +17,7 @@ public enum UserTitle {
     MISS("Miss"),
     MS("Ms"),
     DOCTOR("Doctor"),
+    EMPTY(""),
     UNSPECIFIED("Unspecified");
 
   private String value;

--- a/src/main/java/uk/gov/ccs/swagger/sso/model/UserTitle.java
+++ b/src/main/java/uk/gov/ccs/swagger/sso/model/UserTitle.java
@@ -31,6 +31,7 @@ public enum UserTitle {
   MISS("Miss"),
   MS("Ms"),
   DOCTOR("Doctor"),
+  EMPTY(""),
   UNSPECIFIED("Unspecified");
 
   private String value;

--- a/src/main/resources/conclave_api.yaml
+++ b/src/main/resources/conclave_api.yaml
@@ -4232,6 +4232,7 @@
           "Miss",
           "Ms",
           "Doctor",
+          "",
           "Unspecified"
         ],
         "default": "Unspecified",

--- a/src/main/resources/dm_api.yaml
+++ b/src/main/resources/dm_api.yaml
@@ -299,6 +299,7 @@ components:
         - Miss
         - Ms
         - Doctor
+        - ""
         - Unspecified
       default: Unspecified
       nullable: true


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2452**
Updates swagger spec for DM and ConclaveSSO, so that title validation allows empty string, so that a 400 is not returned.