### PR TITLE
CON-2452-Remove-Pattern-From-Optional-Contact-Email

### DIFF
--- a/src/main/resources/dm_api.yaml
+++ b/src/main/resources/dm_api.yaml
@@ -153,7 +153,6 @@ components:
           nullable: true
         contactEmail:
           type: string
-          pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
           description: User Contact Email. Only applied for new users. Blank treated as null.
           example: abc@somewhere.org
           nullable: true
@@ -209,7 +208,6 @@ components:
           example: Bloggs
         contactEmail:
           type: string
-          pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
           description: User Contact Email
           example: abc@somewhere.org
         userRoles:


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2452**
Remove pattern validation from 'contactEmail' field, in the DM swagger spec, so that it remains optional in a request.