### PR TITLE
CON-2452-Remove-contactEmail-Validation

### DIFF
--- a/src/main/java/uk/gov/ccs/swagger/dataMigration/model/User.java
+++ b/src/main/java/uk/gov/ccs/swagger/dataMigration/model/User.java
@@ -163,7 +163,7 @@ public class User   {
    **/
   @Schema(example = "abc@somewhere.org", description = "User Contact Email. Only applied for new users. Blank treated as null.")
   
-  @Pattern(regexp="^([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$")   public String getContactEmail() {
+    public String getContactEmail() {
     return contactEmail;
   }
 

--- a/src/main/java/uk/gov/ccs/swagger/dataMigration/model/UserMin.java
+++ b/src/main/java/uk/gov/ccs/swagger/dataMigration/model/UserMin.java
@@ -131,7 +131,7 @@ public class UserMin   {
    **/
   @Schema(example = "abc@somewhere.org", description = "User Contact Email")
   
-  @Pattern(regexp="^([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$")   public String getContactEmail() {
+    public String getContactEmail() {
     return contactEmail;
   }
 


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2452**
Remove pattern validation from 'contactEmail' field, so that it remains optional in a request.