### PR TITLE
PPG-221-Remove-Database-Action-For-domainName

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/OrganisationService.java
@@ -155,7 +155,7 @@ public class OrganisationService {
         OrganisationDetail organisationDetail = new OrganisationDetail();
         organisationDetail.setOrganisationId(ciiResponse.getOrganisationId());
         organisationDetail.setRightToBuy(org.isRightToBuy());
-        organisationDetail.setDomainName(org.getDomainName());
+        // organisationDetail.setDomainName(org.getDomainName());
         return organisationDetail;
     }
 


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/PPG-221**
Update DM, so that domainName information is not yet added to the DM database yet, until db is ready.