### PR TITLE
PPG-221-Remove-Database-Action-For-domainName

### DIFF
--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -17,6 +17,7 @@
             <column name="identifier_id" type="VARCHAR(255)"/>
             <column name="org_roles" type="VARCHAR(255)"/>
             <column name="right_to_buy" type="BOOL"/>
+            <column name="domain_name" type="VARCHAR(255)"/>
             <column name="scheme_id" type="VARCHAR(255)"/>
             <column name="status" type="INT"/>
             <column name="status_description" type="VARCHAR(255)"/>


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/PPG-221**
Update DM, so that domainName information is not yet added to the DM database yet, until db is ready.