### PR TITLE
Add-pause-between-user-creation-to-handle-rate

### DIFF
--- a/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
+++ b/src/main/java/uk/gov/ccs/conclave/data/migration/service/UserService.java
@@ -99,6 +99,7 @@ public class UserService {
         Org organisation = response.getOrganisation();
         for (User user : users) {
             try {
+                Thread.sleep(1100);
                 if(checkUserExistsInOrg(user, response.getOrganisationId())) {
                     updateUserRoles(user, response, organisation);
                 } else {
@@ -111,6 +112,8 @@ public class UserService {
                 userFailureCount++;
                 log.error("{}{}: {}", SSO_USER_ERROR_MESSAGE, e.getMessage(), e.getResponseBody());
                 errorService.saveUserDetailWithStatusCode(user, SSO_USER_ERROR_MESSAGE + e.getMessage(), e.getCode(), response.getOrganisation());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
             }
         }
 


### PR DESCRIPTION
Update user migration service, to add in a 1.1 second pause between user creation, in order to help with the PPG Auth0 rate issues.