### PR TITLE
PPG-1180-1181-1182-1208-1209-1224--Major-Updates

### DIFF
--- a/app/controllers/data_migration_controller.rb
+++ b/app/controllers/data_migration_controller.rb
@@ -110,35 +110,29 @@ class DataMigrationController < ApplicationController
         if validator.validate(json_data)
             json_data = json_data.is_a?(String) ? JSON.parse(json_data) : json_data
 
-            data_migration_service = Migrate::DataMigration.new(json_data)
-            dm_migrate_orgs = data_migration_service.migrate_orgs # { responses: nil, report: { dm_orgs_success_list: @orgSuccessList, dm_orgs_error_list: @orgErrorsList } }
-            dm_migrate_orgs_report = dm_migrate_orgs[:report] # { dm_orgs_success_list: @orgSuccessList, dm_orgs_error_list: @orgErrorsList }
-            dm_migrate_users = data_migration_service.migrate_users # { responses: nil, report: { dm_users_success_list: @userSuccessList, dm_users_error_list: @userErrorsList } }
-            dm_migrate_users_report = dm_migrate_users[:report] # { dm_users_success_list: @userSuccessList, dm_users_error_list: @userErrorsList }
-
             cii_migration_service = Migrate::Cii.new(json_data)
-            cii_migrate_orgs = cii_migration_service.migrate_orgs # { responses: @ciiResposeList, report: { cii_orgs_success_list: @orgSuccessList, cii_orgs_error_List: @orgErrorsList } }
-            cii_migrate_orgs_report = cii_migrate_orgs[:report] # { cii_orgs_success_list: @orgSuccessList, cii_orgs_error_List: @orgErrorsList }
-            #cii_response_list = cii_migrate_orgs[:responses]
+            cii_migrate_orgs = cii_migration_service.migrate_orgs # { responses: @response_list, reports: { success_report: @org_success_list, error_report: @org_error_list }, statuses: @response_status_code_list }
 
-            #ppg_migration_service = Migrate::Ppg.new(json_data, cii_response_list)
-            #ppg_migrate_orgs = ppg_migration_service.migrate_orgs # { responses: nil, report: { ppg_orgs_success_list: @orgSuccessList, ppg_orgs_error_list: @orgErrorsList } }
-            #ppg_migrate_orgs_report = ppg_migrate_orgs[:report] # { ppg_orgs_success_list: @orgSuccessList, ppg_orgs_error_list: @orgErrorsList }
-            #ppg_migrate_users = ppg_migration_service.migrate_users # { responses: nil, report: { ppg_users_success_list: @orgSuccessList, ppg_users_error_list: @orgErrorsList } }
-            #ppg_migrate_users_report = ppg_migrate_users[:report] # { ppg_users_success_list: @orgSuccessList, ppg_users_error_list: @orgErrorsList }
+            ppg_migration_service = Migrate::Ppg.new(json_data, cii_migrate_orgs[:responses])
+            ppg_migrate_orgs = ppg_migration_service.migrate_orgs # { responses: nil, reports: { success_report: @org_success_list, error_report: @org_error_list }, statuses: @org_response_status_code_list }
+            # ppg_migrate_users = ppg_migration_service.migrate_users # { responses: nil, reports: { success_report: @user_success_list, error_report: @user_error_list }, statuses: @user_response_status_code_list }
+
+            data_migration_service = Migrate::DataMigration.new(json_data, cii_migrate_orgs[:statuses], ppg_migrate_orgs[:statuses], 'ppg_migrate_users[:statuses]')
+            dm_migrate_orgs = data_migration_service.migrate_orgs # { responses: nil, reports: { report: @org_list }, statuses: nil }
+            dm_migrate_users = data_migration_service.migrate_users # { responses: nil, reports: { report: @user_list }, statuses: nil }
 
             return render json: {
-                dm_migration_report: {
-                    dm_orgs: dm_migrate_orgs_report,
-                    dm_users: dm_migrate_users_report
+                dm_report: {
+                    orgs: dm_migrate_orgs[:reports],
+                    users: dm_migrate_users[:reports]
                 },
-                cii_migration_report: {
-                    cii_orgs: cii_migrate_orgs_report
-                }#,
-                #ppg_migration_report: {
-                    #ppg_orgs: ppg_migrate_orgs_report,
-                    #ppg_users: ppg_migrate_users_report
-                #}
+                cii_report: {
+                    orgs: cii_migrate_orgs[:reports]
+                },
+                ppg_report: {
+                    orgs: ppg_migrate_orgs[:reports],
+                    users: 'ppg_migrate_users[:reports]'
+                }
             }, status: :ok
         else
             return render json: {  error: validator.errors  }, status: :unprocessable_entity

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,3 @@
 class Organisation < ApplicationRecord
-  validates :identifier_id, presence: true, uniqueness: { case_sensitive: false }
-  validates :scheme_id, :domain_name, presence: true
+  validates :identifier_id, :scheme_id, :domain_name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
 class User < ApplicationRecord
-  validates :email, presence: true, uniqueness: { case_sensitive: false }
-  validates :identifier_id, :scheme_id, :first_name, :last_name, presence: true
+  validates :email, :identifier_id, :scheme_id, :first_name, :last_name, presence: true
 end

--- a/app/services/common/helper.rb
+++ b/app/services/common/helper.rb
@@ -2,7 +2,7 @@ module Common
   class Helper
 
     def self.org_type_to_boolean(org_type)
-      return true if org_type == 1 || org_type == 2
+      return true if org_type == 1 || org_type == "1" || org_type == 2 || org_type == "2"
 
       false
     end

--- a/app/services/migrate/cii.rb
+++ b/app/services/migrate/cii.rb
@@ -5,9 +5,10 @@ module Migrate
   class Cii
     def initialize(json_data)
       @data = json_data
-      @orgErrorsList = []
-      @orgSuccessList = []
-      @ciiResponseList = {}
+      @org_success_list = []
+      @org_error_list = []
+      @response_list = {}
+      @response_status_code_list = {}
     end
 
 
@@ -25,29 +26,38 @@ module Migrate
 
         if response.present? && response[:response]
           if response[:response].code.present? && response[:response].code.to_i == 201 && response[:response].body.present?
-            @ciiResponseList["#{org["scheme-id"]}-#{org["identifier-id"]}"] = response[:response].body
-            next @orgSuccessList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 201, data: org  } # Organisation Migrated to CII.
+            @response_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = response[:response].body
+            @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 201  }
+            next @org_success_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 201  } # Organisation Migrated to CII.
           elsif response[:response].code.present? && response[:response].code.to_i == 409 && response[:response].body.present?
-            next @orgSuccessList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 409, data: org  } # Organisation Already Migrated to CII.
+            @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 409  }
+            next @org_success_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 409  } # Organisation Already Migrated to CII.
           elsif response[:response].code.present? && response[:response].code.to_i == 404
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 404, data: org, status_error: 'Not Found Response from CII.', response: response  } # Organisation Not Migrated to CII.
+            @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 404  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 404, status_error: 'Not Found Response from CII.', response: response  } # Organisation Not Migrated to CII.
           elsif response[:response].code.present? && response[:response].code.to_i == 401
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 401, data: org, status_error: 'Unauthorized Response from CII.', response: response  } # Organisation Not Migrated to CII.
+            @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 401  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 401, status_error: 'Unauthorized Response from CII.', response: response  } # Organisation Not Migrated to CII.
           elsif response[:response].code.present? && response[:response].code.to_i == 400
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 400, data: org, status_error: 'Bad Request Response from CII.', response: response  } # Organisation Not Migrated to CII.
+            @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 400  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 400, status_error: 'Bad Request Response from CII.', response: response  } # Organisation Not Migrated to CII.
           elsif response[:response].code.present?
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: response[:response].code.to_i, data: org, status_error: 'Unknown Error from CII.', response: response  } # Organisation Not Migrated to CII.
+            @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: response[:response].code.to_i  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: response[:response].code.to_i, status_error: 'Unknown Error from CII.', response: response  } # Organisation Not Migrated to CII.
           else
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, data: org, status_error: 'Internal Error.', response: response  } # Organisation Not Migrated to CII.
+            @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 500  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, status_error: 'Internal Error.', response: response  } # Organisation Not Migrated to CII.
           end
-        elsif response.present? && response['error']
-          next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, data: org, status_error: response['error'], response: response  } # Organisation Not Migrated to CII.
+        elsif response.present? && response[:error]
+          @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 500  }
+          next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, status_error: response[:error], response: response  } # Organisation Not Migrated to CII.
         else
-          next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, data: org, status_error: 'Empty or No Response from CII. (Either a 500 internal error, a url 404 from the external call, or just no response at all received).', response: nil  } # Organisation Not Migrated to CII.
+          @response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 500  }
+          next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, status_error: 'Empty or No Response from CII. (Either a 500 internal error, a url 404 from the external call, or just no response at all received).', response: nil  } # Organisation Not Migrated to CII.
         end
       end
 
-      return {  responses: @ciiResponseList, report: { cii_orgs_success_list: @orgSuccessList, cii_orgs_error_List: @orgErrorsList }  }
+      return {  responses: @response_list, reports: {  success_report: @org_success_list, error_report: @org_error_list  }, statuses: @response_status_code_list  }
     end
 
 

--- a/app/services/migrate/data_migration.rb
+++ b/app/services/migrate/data_migration.rb
@@ -1,11 +1,13 @@
 module Migrate
   class DataMigration
-    def initialize(json_data)
+    def initialize(json_data, cii_org_status_codes_list, ppg_org_status_codes_list, ppg_user_status_codes_list)
       @data = json_data
-      @orgErrorsList = []
-      @orgSuccessList = []
-      @userErrorsList = []
-      @userSuccessList = []
+      @cii_org_statuses = cii_org_status_codes_list
+      @ppg_org_statuses = ppg_org_status_codes_list
+      @ppg_user_statuses = ppg_user_status_codes_list
+
+      @org_list = []
+      @user_list = []
     end
 
 
@@ -24,31 +26,27 @@ module Migrate
 
     def migrate_orgs_to_db
       @data.each do |org|
-        organisation = Organisation.new(
+        Organisation.new(
           scheme_id: "#{org["scheme-id"]}",
           identifier_id: "#{org["identifier-id"]}",
           right_to_buy: Common::Helper.org_type_to_boolean("#{org["organisationType"]}"),
           domain_name: "#{org["domainName"]}",
           org_roles: Common::Helper.get_roles_from_list(org["orgRoles"]),
-          status: 201,# Need to do DM last? So it can report on the CII and PPG statuses here. It must be on a per ORG basis, in order to carry on with migration with other orgs/users! !!!!!
-          status_description: 'Success.'# Need to do DM last? So it can report on the CII and PPG responses here. It must be on a per ORG basis, in order to carry on with migration with other orgs/users! !!!!!
-        )
+          cii_status: @cii_org_statuses["#{org["scheme-id"]}-#{org["identifier-id"]}"][:status],
+          ppg_status: @ppg_org_statuses["#{org["scheme-id"]}-#{org["identifier-id"]}"][:status]
+        ).save
 
-        if organisation.save
-          next @orgSuccessList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 201, data: org  } # Organisation Saved.
-        else
-          next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, data: org, status_error: organisation.errors, response: nil  } # Organisation Not Saved.
-        end
+          next @org_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", cii_org_status: @cii_org_statuses["#{org["scheme-id"]}-#{org["identifier-id"]}"][:status], ppg_org_status: @ppg_org_statuses["#{org["scheme-id"]}-#{org["identifier-id"]}"][:status], migrated_data: org  }
       end
 
-      return {  responses: nil, report: { dm_orgs_success_list: @orgSuccessList, dm_orgs_error_list: @orgErrorsList }  }
+      return {  responses: nil, reports: {  report: @org_list  }, statuses: nil  }
     end
 
 
     def migrate_users_to_db
       @data.each do |org|
         org["user"].each do |usr|
-          user = User.new(
+          User.new(
             scheme_id: "#{org["scheme-id"]}",
             identifier_id: "#{org["identifier-id"]}",
             contact_email: "#{usr["contactEmail"]}",
@@ -61,19 +59,14 @@ module Migrate
             first_name: "#{usr["firstName"]}",
             last_name: "#{usr["lastName"]}",
             user_roles: Common::Helper.get_roles_from_list(usr["userRoles"]),
-            status: 201,# Need to do DM last? So it can report on the CII and PPG statuses here. It must be on a per USER basis, in order to carry on with migration with other orgs/users! !!!!!
-            status_description: 'Success.'# Need to do DM last? So it can report on the CII and PPG responses here. It must be on a per USER basis, in order to carry on with migration with other orgs/users! !!!!!
-          )
+            ppg_status: 123#@ppg_user_statuses["#{org["scheme-id"]}-#{org["identifier-id"]}"][:status]
+          ).save
 
-          if user.save
-            next @userSuccessList << {  user: "#{usr["email"]}", organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", success: true, status: 201, data: usr  } # User Saved.
-          else
-            next @userErrorsList << {  user: "#{usr["email"]}", organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", success: false, status: 500, data: usr, status_error: user.errors, response: nil  } # User Not Saved.
-          end
+          next @user_list << {  user: "#{usr["email"]}", organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", ppg_user_status: 123, migrated_data: usr  }#@ppg_user_statuses["#{org["scheme-id"]}-#{org["identifier-id"]}"][:status]
         end
       end
 
-      return {  responses: nil, report: { dm_users_success_list: @userSuccessList, dm_users_error_list: @userErrorsList }  }
+      return {  responses: nil, reports: {  report: @user_list  }, statuses: nil  }
     end
   end
 end

--- a/app/services/migrate/ppg.rb
+++ b/app/services/migrate/ppg.rb
@@ -6,10 +6,12 @@ module Migrate
     def initialize(json_data, cii_response_list)
       @data = json_data
       @cii_responses = cii_response_list
-      @orgErrorsList = []
-      @orgSuccessList = []
-      @userErrorsList = []
-      @userSuccessList = []
+      @org_error_list = []
+      @org_success_list = []
+      @user_error_list = []
+      @user_success_list = []
+      @org_response_status_code_list = {}
+      @user_response_status_code_list = {}
     end
 
 
@@ -31,29 +33,41 @@ module Migrate
         response = send_request_to_ppg('/organisation-profile', org)
 
         if response.present? && response[:response]
-          if response[:response].code.present? && response[:response].code.to_i == 201 && response[:response].body.present?
-            next @orgSuccessList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 201, data: org  } # Organisation Migrated to PPG.
-          elsif ((response[:response].code.present? && response[:response].code.to_i == 409 && response[:response].body.present?) || (response[:response] == 409))
-            next @orgSuccessList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 409, data: org  } # Organisation Already Migrated to PPG.
+          if response[:response] == 409
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 409  }
+            next @org_success_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 409  } # Organisation Already Migrated to PPG.
+          elsif response[:response].code.present? && response[:response].code.to_i == 200
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 200  }
+            next @org_success_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 200  } # Organisation Migrated to PPG.
+          elsif response[:response].code.present? && response[:response].code.to_i == 409
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 409  }
+            next @org_success_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: true, status: 409  } # Organisation Already Migrated to PPG.
           elsif response[:response].code.present? && response[:response].code.to_i == 404
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 404, data: org, status_error: 'Not Found Response from PPG.', response: response  } # Organisation Not Migrated to PPG.
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 404  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 404, status_error: 'Not Found Response from PPG.', response: response  } # Organisation Not Migrated to PPG.
           elsif response[:response].code.present? && response[:response].code.to_i == 401
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 401, data: org, status_error: 'Unauthorized Response from PPG.', response: response  } # Organisation Not Migrated to PPG.
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 401  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 401, status_error: 'Unauthorized Response from PPG.', response: response  } # Organisation Not Migrated to PPG.
           elsif response[:response].code.present? && response[:response].code.to_i == 400
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 400, data: org, status_error: 'Bad Request Response from PPG.', response: response  } # Organisation Not Migrated to PPG.
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 400  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 400, status_error: 'Bad Request Response from PPG.', response: response  } # Organisation Not Migrated to PPG.
           elsif response[:response].code.present?
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: response[:response].code.to_i, data: org, status_error: 'Unknown Error from PPG.', response: response  } # Organisation Not Migrated to PPG.
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: response[:response].code.to_i  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: response[:response].code.to_i, status_error: 'Unknown Error from PPG.', response: response  } # Organisation Not Migrated to PPG.
           else
-            next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, data: org, status_error: 'Internal Error.', response: response  } # Organisation Not Migrated to PPG.
+            @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 500  }
+            next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, status_error: 'Internal Error.', response: response  } # Organisation Not Migrated to PPG.
           end
-        elsif response.present? && response['error']
-          next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, data: org, status_error: response['error'], response: response  } # Organisation Not Migrated to PPG.
+        elsif response.present? && response[:error]
+          @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 500  }
+          next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, status_error: response[:error], response: response  } # Organisation Not Migrated to PPG.
         else
-          next @orgErrorsList << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, data: org, status_error: 'Empty or No Response from PPG. (Either a 500 internal error, a url 404 from the external call, or just no response at all received).', response: nil  } # Organisation Not Migrated to PPG.
+          @org_response_status_code_list["#{org["scheme-id"]}-#{org["identifier-id"]}"] = {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", status: 500  }
+          next @org_error_list << {  organisation: "#{org["scheme-id"]}-#{org["identifier-id"]}", successful: false, status: 500, status_error: 'Empty or No Response from PPG. (Either a 500 internal error, a url 404 from the external call, or just no response at all received).', response: nil  } # Organisation Not Migrated to PPG.
         end
       end
 
-      return {  responses: nil, report: { ppg_orgs_success_list: @orgSuccessList, ppg_orgs_error_list: @orgErrorsList }  }
+      return {  responses: nil, reports: {  success_report: @org_success_list, error_report: @org_error_list  }, statuses: @org_response_status_code_list  }
     end
 
 
@@ -64,7 +78,7 @@ module Migrate
       if ENV.fetch('REMOTE_APP', nil) == 'true'
         http.use_ssl = true
       else
-        http.use_ssl = false
+        http.use_ssl = true
       end
 
       if data
@@ -95,15 +109,15 @@ module Migrate
     def build_body(data)
       if @cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"].present?
         return {
-          "identifier": @cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"]['identifier'],
-          "additionalIdentifiers": @cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"]['additionalIdentifier'],
-          "address": @cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"]['address'],
-          "detail": {
-            "organisationId": @cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"]['organisationId'],
-            "supplierBuyerType": data["organisationType"],
-            "rightToBuy": Common::Helper.org_type_to_boolean("#{data["organisationType"]}"),
-            "isActive": true,
-            "domainName": data["domainName"]
+          identifier: JSON.parse(@cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"])['identifier'],
+          additionalIdentifiers: JSON.parse(@cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"])['additionalIdentifier'],
+          address: JSON.parse(@cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"])['address'],
+          detail: {
+            organisationId: JSON.parse(@cii_responses["#{data["scheme-id"]}-#{data["identifier-id"]}"])['organisationId'],
+            supplierBuyerType: data["organisationType"].to_i,
+            rightToBuy: Common::Helper.org_type_to_boolean("#{data["organisationType"]}"),
+            isActive: true,
+            domainName: data["domainName"]
           }
         }.to_json
       else

--- a/db/migrate/20240530152659_data_migration.rb
+++ b/db/migrate/20240530152659_data_migration.rb
@@ -7,7 +7,6 @@ class DataMigration < ActiveRecord::Migration[7.1]
 
       t.timestamps
     end
-
     add_index :clients, [:client_id, :api_key], unique: true
 
     create_table :organisations, id: false do |t|
@@ -16,14 +15,13 @@ class DataMigration < ActiveRecord::Migration[7.1]
       t.string :org_roles
       t.boolean :right_to_buy
       t.string :scheme_id, null: false
-      t.integer :status
-      t.string :status_description
+      t.integer :cii_status
+      t.integer :ppg_status
       t.string :domain_name
 
       t.timestamps
     end
-
-    add_index :organisations, [:org_id, :identifier_id], unique: true
+    add_index :organisations, [:org_id], unique: true
 
     create_table :users, id: false do |t|
       t.bigserial :user_id, primary_key: true
@@ -35,8 +33,7 @@ class DataMigration < ActiveRecord::Migration[7.1]
       t.string :email, null: false
       t.string :first_name, null: false
       t.string :last_name, null: false
-      t.integer :status
-      t.string :status_description
+      t.integer :ppg_status
       t.string :title
       t.string :user_roles
       t.string :identifier_id, null: false
@@ -44,7 +41,6 @@ class DataMigration < ActiveRecord::Migration[7.1]
 
       t.timestamps
     end
-
-    add_index :users, [:user_id, :email], unique: true
+    add_index :users, [:user_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,12 +27,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_152659) do
     t.string "org_roles"
     t.boolean "right_to_buy"
     t.string "scheme_id", null: false
-    t.integer "status"
-    t.string "status_description"
+    t.integer "cii_status"
+    t.integer "ppg_status"
     t.string "domain_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["org_id", "identifier_id"], name: "index_organisations_on_org_id_and_identifier_id", unique: true
+    t.index ["org_id"], name: "index_organisations_on_org_id", unique: true
   end
 
   create_table "users", primary_key: "user_id", force: :cascade do |t|
@@ -44,15 +44,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_152659) do
     t.string "email", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.integer "status"
-    t.string "status_description"
+    t.integer "ppg_status"
     t.string "title"
     t.string "user_roles"
     t.string "identifier_id", null: false
     t.string "scheme_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id", "email"], name: "index_users_on_user_id_and_email", unique: true
+    t.index ["user_id"], name: "index_users_on_user_id", unique: true
   end
 
 end


### PR DESCRIPTION
**PPG-1180:**
 - Change DM database table columns to reflect required data. Add config to support new or updated fields.
 - Update response report to be clearer, and reflect status of other migrations.
 - Updated data layer so that repeat organisations and users can be stored now.

**PPG-1181:**
 - Store response information, that is needed for calls to PPG and also DM's own data stores or reporting.
 - Update response report to be clearer.

**PPG-1182:**
 - Fixed bugs relating to posting data to org profile in PPG.
 - Store response information, that is needed for DM's own data stores or reporting.
 - Update response report to be clearer.

**PPG-1208:**
 - Fixed this reported bug, where a 500 response was given when re-posting an organisation that had been deleted in CII.

**PPG-1209:**
 - Fixed this reported issue.

**PPG-1224:**
 - Response report will now accurately and consistently reflect the response codes received from all external calls.