### PR TITLE
PPG-1291-1288--Fix-issue-where-500-status-was-reported-plus-more-fixes

### DIFF
--- a/app/services/common/helper.rb
+++ b/app/services/common/helper.rb
@@ -9,6 +9,8 @@ module Common
 
 
     def self.parse_comma_separated_list(data_list)
+      return [] if data_list.blank?
+
       data_list.split(',').map { |item| { 'key' => item.strip } }
     end
 

--- a/app/services/migrate/ppg_users.rb
+++ b/app/services/migrate/ppg_users.rb
@@ -150,6 +150,7 @@ module Migrate
       end
 
       return {  request: request, response: Struct.new(:code).new(500), status_description: 'Internal Error.'  } if data.present? && request.body.nil?
+      return {  request: request, response: Struct.new(:code).new(204), status_description: 'No contact data to send. New contact not needed.'  } if data.present? && request.body == 'NA'
 
       begin
         response = http.request(request)
@@ -252,7 +253,7 @@ module Migrate
         no_data_count+= 1
       end
 
-      return nil if no_data_count >= 5
+      return 'NA' if no_data_count >= 5
 
       return {
         contactPointReason: "GENERAL",


### PR DESCRIPTION
**PPG-1291 & PPG-1288:**
 - Fixes an issue where 500 internal error was incorrectly reported in events where no call to the contact service was needed.
 - Also fixes and internal server 500 error when no org roles or user roles were included in the request payload.